### PR TITLE
feat(signals): migrate llm_macro to OpenAI 1.x, add safe-mode & model env

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ Run the bot in simulation or paper mode:
 python -m cli.run_bot --backend sim   # default
 python -m cli.run_bot --backend paper
 ```
+
+## Environment vars
+
+* OPENAI_MODEL – override model for macro signal (default gpt-4o-mini)

--- a/atlasbot/config.py
+++ b/atlasbot/config.py
@@ -30,3 +30,8 @@ EXECUTION_BACKEND = "sim"  # "paper" | "live" (future)
 WS_URL_PRO      = "wss://ws-feed.exchange.coinbase.com"       # legacy
 WS_URL_ADVANCED = "wss://advanced-trade-ws.coinbase.com"      # new
 REST_TICKER_FMT = "https://api.exchange.coinbase.com/products/{}/ticker"
+
+# --- LLM configuration ------------------------------------------------------
+import os
+
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-openai
+openai>=1.0,<2
 boto3
 python-dotenv
 pandas

--- a/tests/test_llm_macro.py
+++ b/tests/test_llm_macro.py
@@ -1,0 +1,21 @@
+import atlasbot.signals.llm_macro as lm
+
+class Resp:
+    def __init__(self):
+        self.choices = [type("X", (object,), {
+            "message": type("Y", (object,), {
+                "content": '{"bias":"long","confidence":0.6,"headline":"test"}'
+            })()
+        })]
+
+def test_macro_bias(monkeypatch):
+    monkeypatch.setattr(lm.client.chat.completions, "create", lambda *a, **k: Resp())
+    monkeypatch.setattr(lm.client, "api_key", "x")
+    monkeypatch.setattr(lm, "_macro", lm.MacroBias())
+    assert lm.macro_bias("BTC-USD") == 0.6
+
+def test_safe_mode(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(lm.client, "api_key", "")
+    monkeypatch.setattr(lm, "_macro", lm.MacroBias())
+    assert lm.macro_bias("BTC-USD") == 0.0


### PR DESCRIPTION
## Summary
- migrate `llm_macro` to OpenAI client v1
- implement safe-mode handling for missing key or API failure
- configure model via new `OPENAI_MODEL` env var
- pin OpenAI in requirements
- document environment variable
- add tests for macro bias

## Testing
- `pytest -q`

## Summary by Sourcery

Migrate the LLM macro to OpenAI client v1 with configurable model and robust failure handling, while pinning dependencies, adding tests, and updating docs.

Enhancements:
- Migrate `llm_macro` to use the OpenAI v1 client API
- Implement safe-mode for missing API key or LLM errors with hourly warnings
- Expose `OPENAI_MODEL` environment variable for model configuration
- Pin `openai` dependency to version 1.x

Documentation:
- Document the `OPENAI_MODEL` environment variable in README

Tests:
- Add unit tests for `macro_bias` and safe-mode behavior