### PR TITLE
Handle OpenAI key via env or AWS

### DIFF
--- a/atlasbot/ai_desk.py
+++ b/atlasbot/ai_desk.py
@@ -3,7 +3,9 @@ import asyncio
 import os
 import openai
 
-openai.api_key = os.getenv("OPENAI_API_KEY", "")
+from atlasbot.secrets_loader import get_openai_api_key
+
+openai.api_key = get_openai_api_key()
 
 
 class AIDesk:

--- a/atlasbot/gpt_report.py
+++ b/atlasbot/gpt_report.py
@@ -1,4 +1,7 @@
 import openai
+from atlasbot.secrets_loader import get_openai_api_key
+
+openai.api_key = get_openai_api_key()
 from datetime import datetime, timedelta, timezone
 
 class GPTTrendAnalyzer:

--- a/atlasbot/secrets_loader.py
+++ b/atlasbot/secrets_loader.py
@@ -2,6 +2,7 @@
 import boto3
 import base64
 import json
+import os
 from botocore.exceptions import ClientError
 
 def load_secret(secret_name: str, region_name: str = "us-east-1") -> dict:
@@ -34,5 +35,8 @@ def get_coinbase_credentials():
     }
 
 def get_openai_api_key():
+    env_key = os.getenv("OPENAI_API_KEY")
+    if env_key:
+        return env_key
     secret = load_secret("atlasbot/openai")
     return secret.get("OPENAI_API_KEY", "")

--- a/atlasbot/signals/llm_macro.py
+++ b/atlasbot/signals/llm_macro.py
@@ -3,10 +3,9 @@ import logging
 from datetime import datetime, timedelta, timezone
 from openai import OpenAI
 from atlasbot.config import OPENAI_MODEL
+from atlasbot.secrets_loader import get_openai_api_key
 
-import os
-
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY", ""))
+client = OpenAI(api_key=get_openai_api_key())
 
 PROMPT = (
     "Summarise the last 12 hours of crypto news. "

--- a/atlasbot/trader.py
+++ b/atlasbot/trader.py
@@ -21,6 +21,7 @@ from atlasbot.config import (
 )
 from atlasbot import risk
 from atlasbot.ai_desk import AIDesk
+from atlasbot.secrets_loader import get_openai_api_key
 
 
 class TradingBot:
@@ -178,7 +179,7 @@ class IntradayTrader:
 
 
 async def desk_runner():
-    if not os.getenv("OPENAI_API_KEY"):
+    if not get_openai_api_key():
         logging.info("[GPT disabled] no OPENAI_API_KEY")
         return
     desk = AIDesk()


### PR DESCRIPTION
## Summary
- load OPENAI_API_KEY from environment or AWS Secrets Manager
- set the OpenAI key consistently across GPT modules
- check the key in `desk_runner` via `secrets_loader`

## Testing
- `pytest -q`