### PR TITLE
Add dotenv support for secrets loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ written to `logs/ai_advisor.log` every 10 minutes when `OPENAI_API_KEY` is set.
 * OPENAI_MODEL – override model for macro signal (default gpt-4o-mini)
 * LOG_LEVEL    – Python logging level (DEBUG/INFO/WARN)
 * COINBASE_PAPER_KEY – enable real Coinbase paper trading
-* OPENAI_API_KEY – enable GPT desk summaries
+* OPENAI_API_KEY – enable GPT desk summaries. This can also be provided via a
+  `.env` file in the project root using `OPENAI_API_KEY=...`.
 
 ## Troubleshooting
 

--- a/atlasbot/secrets_loader.py
+++ b/atlasbot/secrets_loader.py
@@ -3,7 +3,11 @@ import boto3
 import base64
 import json
 import os
+from dotenv import load_dotenv
 from botocore.exceptions import ClientError
+
+load_dotenv()
+
 
 def load_secret(secret_name: str, region_name: str = "us-east-1") -> dict:
     try:
@@ -37,6 +41,6 @@ def get_coinbase_credentials():
 def get_openai_api_key():
     env_key = os.getenv("OPENAI_API_KEY")
     if env_key:
-        return env_key
+        return env_key.strip()
     secret = load_secret("atlasbot/openai")
-    return secret.get("OPENAI_API_KEY", "")
+    return secret.get("OPENAI_API_KEY", "").strip()


### PR DESCRIPTION
## Summary
- load environment variables from a `.env` file
- trim whitespace from the OpenAI key
- document `.env` support in README

## Testing
- `pytest -q`

## Summary by Sourcery

Add dotenv support to the secrets loader, ensure the OpenAI API key is trimmed of whitespace, and update project documentation to reflect .env usage.

New Features:
- Add support for loading environment variables from a .env file

Enhancements:
- Trim whitespace from the OpenAI API key when retrieved from environment or secrets

Documentation:
- Document .env file support for OPENAI_API_KEY in the README