### PR TITLE
Graceful ATR warm-up handling

### DIFF
--- a/atlasbot/trader.py
+++ b/atlasbot/trader.py
@@ -173,7 +173,11 @@ class IntradayTrader:
             advice = self.engine.next_advice(symbol)
             side = "buy" if advice["bias"] == "long" else "sell"
             price = fetch_price(symbol)
-            atr = calculate_atr(symbol)
+            try:
+                atr = calculate_atr(symbol)
+            except RuntimeError:
+                logging.info("[%s] waiting for live data warm-up…", symbol)
+                continue
             equity = risk.equity()
             conf = max(advice.get("confidence", 0.0), 0.0)
             size_usd = equity * RISK_PER_TRADE * conf / (atr / price if atr else 1)


### PR DESCRIPTION
## Summary
- log and skip symbols when ATR history is insufficient

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'atlasbot')*

## Summary by Sourcery

Enhancements:
- Catch ATR warm-up errors to log a message and skip symbols until sufficient data is available