### PR TITLE
feat(core): finalize profit-first exits, safeguards, docs & slim build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - run: pip install -r requirements.txt
+      - run: pip install pytest
+      - run: pytest -q
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build image
+        run: docker build -t atlasbot:slim .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## Unreleased
+- Profit-first exits with ATR TP/SL
+- Maker vs taker tracking and conflict debounce
+- Circuit breaker and feed watchdog safeguards
+- Thread-safe ledger with stress test
+- Slim Dockerfile and CI cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim AS build
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+
+FROM python:3.11-slim
+WORKDIR /app
+COPY --from=build /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=build /app /app
+CMD ["python", "-m", "cli.run_bot"]

--- a/README.md
+++ b/README.md
@@ -29,12 +29,20 @@ python -m cli.run_bot --backend paper
 Metrics are exposed at http://localhost:9000/metrics. GPT desk summaries are
 written to `logs/ai_advisor.log` every 10 minutes when `OPENAI_API_KEY` is set.
 
+Metrics include `atlasbot_feed_watchdog_total` alongside PnL and latency gauges.
+
 ## Environment vars
 
 * OPENAI_API_KEY      – optional, enable GPT desk
 * COINBASE_PAPER_KEY  – optional, send orders to Coinbase paper
 * LOG_LEVEL           – DEBUG|INFO|WARN|ERROR (default INFO)
 * OPENAI_MODEL        – override model for macro signal (default gpt-4o-mini)
+* EXECUTION_MODE      – sim | paper (default sim)
+* MIN_EDGE_BPS        – minimum edge threshold
+* K_TP                – ATR-based take profit multiplier
+* K_SL                – ATR-based stop loss multiplier
+* MAX_HOLD_MIN        – maximum hold time in minutes
+* ALLOW_CONFLICT      – allow conflict trades if true
 
 ## Troubleshooting
 

--- a/atlasbot/__init__.py
+++ b/atlasbot/__init__.py
@@ -1,5 +1,7 @@
 """AtlasBot – automated crypto trading package."""
+
 from dotenv import load_dotenv
+
 load_dotenv()
 __all__ = [
     "config",
@@ -13,4 +15,4 @@ __all__ = [
     "risk",
     "execution",
 ]
-__version__ = "0.1.0"
+__version__ = "0.3.0"

--- a/atlasbot/config.py
+++ b/atlasbot/config.py
@@ -1,20 +1,38 @@
 # --- traded symbols ---------------------------------------------------------
+import os
+
 SYMBOLS = [
-    "BTC-USD", "ETH-USD", "DOGE-USD", "AVAX-USD", "SUI-USD", "XLM-USD",
-    "HBAR-USD", "ADA-USD", "DOT-USD", "LINK-USD", "SOL-USD",
+    "BTC-USD",
+    "ETH-USD",
+    "DOGE-USD",
+    "AVAX-USD",
+    "SUI-USD",
+    "XLM-USD",
+    "HBAR-USD",
+    "ADA-USD",
+    "DOT-USD",
+    "LINK-USD",
+    "SOL-USD",
 ]
 
 # --- strategy parameters ----------------------------------------------------
-SLIPPAGE_BPS = 4              # simulated slippage (basis points)
-EDGE_BPS = 3                  # desired edge after costs
+SLIPPAGE_BPS = 4  # simulated slippage (basis points)
+# fee and minimum edge thresholds
+FEE_BPS = int(0.0025 * 10_000)
+FEE_FLAT = 0.10
+MIN_EDGE_BPS = 3
+CURRENT_TAKER_BPS = FEE_BPS
+CURRENT_MAKER_BPS = FEE_BPS
 
 
 def profit_target(sym: str) -> float:
     """Return cost-aware profit target for *sym* as a percentage."""
-    fee_bps = TAKER_FEE * 10_000
+    fee_bps = FEE_BPS
     slip = SLIPPAGE_BPS
-    return (fee_bps + slip + EDGE_BPS) / 10_000
-MAX_NOTIONAL_USD = 100          # risk cap per position
+    return (fee_bps + slip + MIN_EDGE_BPS) / 10_000
+
+
+MAX_NOTIONAL_USD = 100  # risk cap per position
 LOG_PATH = "data/logs/sim_tradesOverNight.csv"
 
 # --- alpha weights ----------------------------------------------------------
@@ -31,23 +49,57 @@ RISK_PER_TRADE = 0.002
 EXECUTION_BACKEND = "sim"  # "paper" | "live" (future)
 
 # --- data feed URLs ---------------------------------------------------------
-WS_URL_PRO      = "wss://ws-feed.exchange.coinbase.com"       # legacy
-WS_URL_ADVANCED = "wss://advanced-trade-ws.coinbase.com"      # new
+WS_URL_PRO = "wss://ws-feed.exchange.coinbase.com"  # legacy
+WS_URL_ADVANCED = "wss://advanced-trade-ws.coinbase.com"  # new
 REST_TICKER_FMT = "https://api.exchange.coinbase.com/products/{}/ticker"
 
 # --- LLM configuration ------------------------------------------------------
-import os
-
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 
 # --- misc -----------------------------------------------------------------
 LOG_HEARTBEAT_S = 60
 DESK_SUMMARY_S = 600
-FEE_MIN_USD = 0.10
+FEE_MIN_USD = FEE_FLAT
 
 # execution costs
-TAKER_FEE = 0.0025            # Coinbase taker fee
+TAKER_FEE = 0.0025  # Coinbase taker fee
 
 # starting capital
 START_CASH = 50_000.0
 
+
+_last_fee_check = 0.0
+
+
+def refresh_fee_tier() -> None:
+    """Refresh maker/taker fees from Coinbase and adjust edge threshold."""
+    global CURRENT_MAKER_BPS, CURRENT_TAKER_BPS, MIN_EDGE_BPS, _last_fee_check
+    import time
+
+    import requests
+
+    if time.time() - _last_fee_check < 3600:
+        return
+    try:
+        r = requests.get("https://api.exchange.coinbase.com/fees", timeout=5)
+        if r.ok:
+            j = r.json()
+            CURRENT_MAKER_BPS = int(float(j.get("maker_fee_rate", 0)) * 10_000)
+            CURRENT_TAKER_BPS = int(float(j.get("taker_fee_rate", 0)) * 10_000)
+            MIN_EDGE_BPS = 2 if CURRENT_TAKER_BPS < FEE_BPS else 3
+            _last_fee_check = time.time()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def start_fee_updater() -> None:
+    """Start background thread for hourly fee updates."""
+    import threading
+    import time
+
+    def _loop() -> None:
+        while True:
+            refresh_fee_tier()
+            time.sleep(3600)
+
+    threading.Thread(target=_loop, daemon=True).start()

--- a/data/fills/2025-05-29.jsonl
+++ b/data/fills/2025-05-29.jsonl
@@ -1,0 +1,3 @@
+{"timestamp": "2025-05-29T19:57:03.836989+00:00", "symbol": "BTC-USD", "side": "buy", "notional": 100, "price": 100.0, "fee": 0.25, "slip": 0.0, "realised": 0.0, "mtm": 0.0}
+{"timestamp": "2025-05-29T19:57:03.842210+00:00", "symbol": "BTC-USD", "side": "sell", "notional": 50, "price": 100.0, "fee": 0.125, "slip": 0.0, "realised": 0.0, "mtm": 0.0}
+{"timestamp": "2025-05-29T19:57:03.846938+00:00", "symbol": "BTC-USD", "side": "buy", "notional": 100, "price": 100, "fee": 0.25, "slip": 0.0, "realised": 0.0, "mtm": 0.0}

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name="atlasbot",
-    version="0.1.0",
-    packages=find_packages(),   # finds the inner atlasbot package
+    version="0.3.0",
+    packages=find_packages(),  # finds the inner atlasbot package
     python_requires=">=3.10",
 )

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,0 +1,13 @@
+import importlib
+
+import atlasbot.risk as risk_mod
+
+
+def test_circuit_breaker(monkeypatch):
+    risk = importlib.reload(risk_mod)
+    risk._risk.equity = 98.0
+    risk._risk.day_start_equity = 100.0
+    monkeypatch.setattr(risk.time, "time", lambda: 1000.0)
+    assert risk.check_circuit_breaker()
+    assert risk.circuit_breaker_active()
+    assert risk._circuit_until == 1000.0 + 3600

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,55 @@
+import atlasbot.config as cfg
+import atlasbot.trader as tr
+
+
+class DummyExec:
+    def __init__(self):
+        self.calls = []
+
+    def submit_order(self, side: str, size_usd: float, symbol: str):
+        self.calls.append((side, size_usd, symbol))
+
+
+class DummyEngine:
+    def __init__(self, advice):
+        self._advice = advice
+
+    def next_advice(self, symbol: str):
+        return self._advice
+
+
+def _setup_bot(monkeypatch, advice):
+    monkeypatch.setattr(tr, "SYMBOLS", ["BTC-USD"])
+    monkeypatch.setattr(cfg, "SYMBOLS", ["BTC-USD"])
+    monkeypatch.setattr(tr, "fetch_price", lambda s: 100.0)
+    monkeypatch.setattr(tr, "calculate_atr", lambda s: 1.0)
+    monkeypatch.setattr(tr.risk, "check_risk", lambda order: True)
+    dummy = DummyExec()
+    monkeypatch.setattr(tr, "get_backend", lambda name=None: dummy)
+    bot = tr.IntradayTrader(decision_engine=DummyEngine(advice), backend="sim")
+    return bot, dummy
+
+
+def test_flat_bias(monkeypatch):
+    advice = {
+        "bias": "flat",
+        "edge": 0.0,
+        "confidence": 0.0,
+        "rationale": {"orderflow": 0.0, "momentum": 0.0, "macro": 0.0},
+    }
+    bot, dummy = _setup_bot(monkeypatch, advice)
+    bot.run_cycle()
+    assert not dummy.calls
+
+
+def test_conflict_filter(monkeypatch):
+    advice = {
+        "bias": "long",
+        "edge": 0.05,
+        "confidence": 1.0,
+        "rationale": {"orderflow": -0.5, "momentum": 0.5, "macro": 0.0},
+    }
+    bot, dummy = _setup_bot(monkeypatch, advice)
+    for _ in range(3):
+        bot.run_cycle()
+    assert not dummy.calls

--- a/tests/test_ledger_threadsafe.py
+++ b/tests/test_ledger_threadsafe.py
@@ -1,0 +1,17 @@
+import concurrent.futures
+import importlib
+
+import atlasbot.risk as risk_mod
+
+
+def test_ledger_threadsafe(monkeypatch):
+    risk = importlib.reload(risk_mod)
+    monkeypatch.setattr(risk, "fetch_price", lambda s: 100.0)
+
+    def worker():
+        risk.record_fill("BTC-USD", "buy", 100, 100, 0.1, 0.0)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as ex:
+        for _ in range(1000):
+            ex.submit(worker)
+    assert len(risk._risk.trades) == 1000

--- a/tests/test_profit_target.py
+++ b/tests/test_profit_target.py
@@ -4,4 +4,4 @@ import atlasbot.config as cfg
 def test_profit_target_edge():
     for sym in cfg.SYMBOLS:
         pt = cfg.profit_target(sym)
-        assert pt > cfg.TAKER_FEE + cfg.SLIPPAGE_BPS / 10_000
+        assert pt > (cfg.FEE_BPS + cfg.SLIPPAGE_BPS) / 10_000

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,0 +1,32 @@
+import importlib
+
+import atlasbot.metrics as metrics_mod
+
+
+class DummyMarket:
+    def __init__(self):
+        self._symbols = ["BTC-USD"]
+
+    def feed_latency(self):
+        return 130.0
+
+
+def test_watchdog(monkeypatch):
+    metrics = importlib.reload(metrics_mod)
+    dummy = DummyMarket()
+    monkeypatch.setattr(metrics, "get_market", lambda: dummy)
+
+    def fake_get(url, timeout=5):
+        class Resp:
+            ok = True
+
+            def json(self):
+                return {"price": "101"}
+
+        return Resp()
+
+    monkeypatch.setattr(metrics.requests, "get", fake_get)
+    before = metrics.feed_watchdog_total._value.get()
+    metrics.feed_watchdog_check()
+    after = metrics.feed_watchdog_total._value.get()
+    assert after == before + 1


### PR DESCRIPTION
## Summary
- add hourly fee tier updater and dynamic edge threshold
- implement circuit breaker and feed watchdog
- make ledger thread-safe with stress test
- update docs and changelog for Sprint #3
- add CI workflow and slim Dockerfile

## Testing
- `pytest -q`

## Summary by Sourcery

Finalize core exit strategies and safeguards, improve dynamic fee management and metrics, and streamline build and CI workflows

New Features:
- Add hourly fee tier updater with dynamic edge threshold adjustments
- Implement circuit breaker to halt trading for an hour after a 2% daily drawdown
- Introduce feed latency watchdog with automatic REST price fallback
- Add conflict filter to debounce trades when orderflow and momentum signals conflict

Enhancements:
- Make ledger operations thread-safe with locks and stress-tested coverage
- Unify and centralize configuration parameters under atlasbot.config
- Enhance Prometheus metrics registry and include feed watchdog counter
- Handle fetch_price failures gracefully with default fallbacks

Build:
- Add multi-stage slim Dockerfile to reduce image size

CI:
- Add GitHub Actions CI workflow for running tests and building Docker image

Documentation:
- Update README with new metrics and environment variable settings
- Add CHANGELOG documenting Sprint #3 updates

Tests:
- Add tests for profit target calculation, circuit breaker, feed watchdog, thread-safe ledger, and conflict filter

Chores:
- Bump package version to 0.3.0