### PR TITLE
Add fee-aware maker execution and ledger snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
           cache: 'pip'
       - run: pip install -r requirements.txt
       - run: pip install pytest
+      - run: pip install -e .
       - run: pytest -q
   docker:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,7 @@
 - Circuit breaker and feed watchdog safeguards
 - Thread-safe ledger with stress test
 - Slim Dockerfile and CI cache
+- Fee updater thread activated automatically
+- Ledger snapshots written every minute
+- Maker fill ratio metric exposed
+- Configurable max hold time via MAX_HOLD_MIN

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ Mini research and trading framework for Coinbase markets.
                                     execution
 ```
 
+## Installation
+
+```bash
+pip install -r requirements.txt
+pip install -e .
+```
+
+Tests expect the package to be installed in editable mode.
+
 ## Usage
 
 Run the bot in simulation or paper mode:
@@ -25,6 +34,8 @@ Run the bot in simulation or paper mode:
 python -m cli.run_bot --backend sim   # default
 python -m cli.run_bot --backend paper
 ```
+
+Fees are refreshed hourly by a background updater started at launch.
 
 Metrics are exposed at http://localhost:9000/metrics. GPT desk summaries are
 written to `logs/ai_advisor.log` every 10 minutes when `OPENAI_API_KEY` is set.

--- a/atlasbot/config.py
+++ b/atlasbot/config.py
@@ -61,6 +61,9 @@ LOG_HEARTBEAT_S = 60
 DESK_SUMMARY_S = 600
 FEE_MIN_USD = FEE_FLAT
 
+# configurable max hold time for live and simulated trades (minutes)
+MAX_HOLD_MIN = int(os.getenv("MAX_HOLD_MIN", "30"))
+
 # execution costs
 TAKER_FEE = 0.0025  # Coinbase taker fee
 

--- a/atlasbot/execution/__init__.py
+++ b/atlasbot/execution/__init__.py
@@ -1,4 +1,3 @@
-from importlib import import_module
 from atlasbot.config import EXECUTION_BACKEND
 
 
@@ -6,8 +5,10 @@ def get_backend(name: str | None = None):
     backend = name or EXECUTION_BACKEND
     if backend == "sim":
         from . import sim
+
         return sim
     if backend == "paper":
         from . import paper
+
         return paper
     raise ValueError(f"unknown backend {backend}")

--- a/atlasbot/execution/base.py
+++ b/atlasbot/execution/base.py
@@ -14,11 +14,16 @@ FILL_DIR = "data/fills"
 
 
 def log_fill(
-    symbol: str, side: str, notional: float, price: float, slip: float = 0.0
+    symbol: str,
+    side: str,
+    notional: float,
+    price: float,
+    slip: float = 0.0,
+    maker: bool = False,
 ) -> None:
     """Print fill info and append to pnl.csv and jsonl fills."""
     fee = max(notional * TAKER_FEE, FEE_MIN_USD)
-    realised, mtm = risk.record_fill(symbol, side, notional, price, fee, slip)
+    realised, mtm = risk.record_fill(symbol, side, notional, price, fee, slip, maker)
     risk.check_circuit_breaker()
     ts = datetime.now(timezone.utc)
     print(
@@ -45,3 +50,10 @@ def log_fill(
     fpath = os.path.join(FILL_DIR, f"{ts.date()}.jsonl")
     with open(fpath, "a") as f:
         f.write(json.dumps(row) + "\n")
+
+
+def submit_maker_order(
+    side: str, size_usd: float, symbol: str
+) -> tuple[str, float, float] | None:
+    """Submit a maker (post-only) order. Return fill tuple or None."""
+    raise NotImplementedError

--- a/atlasbot/execution/paper.py
+++ b/atlasbot/execution/paper.py
@@ -1,7 +1,10 @@
 import os
 import time
+
 import requests
+
 from atlasbot.utils import fetch_price
+
 from .base import log_fill
 
 
@@ -37,3 +40,36 @@ def submit_order(side: str, size_usd: float, symbol: str) -> str:
         qty = size_usd / price
         log_fill(symbol, side, size_usd, price, 0.0)
         return "paper-error", qty, price
+
+
+def submit_maker_order(side: str, size_usd: float, symbol: str):
+    """Maker order via paper API, return None if not filled."""
+    api_key = os.getenv("COINBASE_PAPER_KEY")
+    if not api_key:
+        return None
+    endpoint = "https://api.coinbase.com/api/v3/brokerage/orders"  # paper
+    payload = {
+        "side": side,
+        "client_order_id": f"maker-{int(time.time())}",
+        "product_id": symbol,
+        "size": str(size_usd / fetch_price(symbol)),
+        "type": "limit",
+        "post_only": True,
+        "limit_price": str(fetch_price(symbol)),
+    }
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    try:
+        r = requests.post(endpoint, json=payload, headers=headers, timeout=5)
+        r.raise_for_status()
+        data = r.json()
+        if not data.get("success", True):
+            return None
+        order_id = data.get("order_id", f"maker-{int(time.time())}")
+        price = float(data.get("average_filled_price", fetch_price(symbol)))
+        qty = float(data.get("filled_size", 0))
+        if qty:
+            log_fill(symbol, side, qty * price, price, 0.0, maker=True)
+            return order_id, qty, price
+    except Exception:
+        pass
+    return None

--- a/atlasbot/execution/sim.py
+++ b/atlasbot/execution/sim.py
@@ -1,7 +1,9 @@
-import time
 import random
-from atlasbot.utils import fetch_price
+import time
+
 from atlasbot.config import SLIPPAGE_BPS
+from atlasbot.utils import fetch_price
+
 from .base import log_fill
 
 
@@ -14,3 +16,14 @@ def submit_order(side: str, size_usd: float, symbol: str) -> str:
     exec_id = f"sim-{time.time()}"
     log_fill(symbol, side, size_usd, fill_price, size_usd * slip_pct)
     return exec_id, qty, fill_price
+
+
+def submit_maker_order(side: str, size_usd: float, symbol: str):
+    """Attempt maker order; 50% chance to fill."""
+    if random.random() < 0.5:
+        price = fetch_price(symbol)
+        qty = size_usd / price
+        exec_id = f"maker-{time.time()}"
+        log_fill(symbol, side, size_usd, price, 0.0, maker=True)
+        return exec_id, qty, price
+    return None

--- a/atlasbot/gpt_report.py
+++ b/atlasbot/gpt_report.py
@@ -1,13 +1,17 @@
+from datetime import datetime, timedelta, timezone
+
 import openai
+
 from atlasbot.secrets_loader import get_openai_api_key
 
 openai.api_key = get_openai_api_key()
-from datetime import datetime, timedelta, timezone
+
 
 class GPTTrendAnalyzer:
     """
     Caches GPT sentiment per symbol; refreshes every `ttl_minutes`.
     """
+
     def __init__(self, enabled: bool = True, ttl_minutes: int = 30):
         self.enabled = enabled
         self.ttl = timedelta(minutes=ttl_minutes)
@@ -36,7 +40,7 @@ class GPTTrendAnalyzer:
         )
         try:
             resp = openai.ChatCompletion.create(
-                model="gpt-4o-mini",     # cheaper model for high-freq calls
+                model="gpt-4o-mini",  # cheaper model for high-freq calls
                 messages=[{"role": "user", "content": prompt}],
                 temperature=0.3,
                 max_tokens=1,

--- a/atlasbot/market_data.py
+++ b/atlasbot/market_data.py
@@ -289,8 +289,13 @@ class MarketData:
             if now >= last + timedelta(minutes=1):
                 for s, prices in bucket.items():
                     if prices:
-                        o, h, l, c = prices[0], max(prices), min(prices), prices[-1]
-                        self._bars[s].append((o, h, l, c))
+                        o, h, low, c = (
+                            prices[0],
+                            max(prices),
+                            min(prices),
+                            prices[-1],
+                        )
+                        self._bars[s].append((o, h, low, c))
                 bucket.clear()
                 last = now.replace(second=0, microsecond=0)
             time.sleep(1)

--- a/atlasbot/metrics.py
+++ b/atlasbot/metrics.py
@@ -6,7 +6,7 @@ from prometheus_client import CollectorRegistry, Counter, Gauge, start_http_serv
 
 from atlasbot.config import REST_TICKER_FMT
 from atlasbot.market_data import get_market
-from atlasbot.risk import cash, daily_pnl, equity, gross, total_mtm
+from atlasbot.risk import cash, daily_pnl, equity, gross, maker_fill_ratio, total_mtm
 from atlasbot.signals import poll_latency
 
 REGISTRY = CollectorRegistry()
@@ -37,6 +37,9 @@ gross_pos_g = Gauge(
 cash_g = Gauge("atlasbot_cash_usd", "Available cash", registry=REGISTRY)
 equity_g = Gauge("atlasbot_equity_usd", "Total account equity", registry=REGISTRY)
 heartbeat_g = Gauge("bot_alive", "Bot heartbeat", registry=REGISTRY)
+maker_ratio_g = Gauge(
+    "atlasbot_maker_fill_ratio", "Maker to total fill ratio", registry=REGISTRY
+)
 gpt_errors_total = Counter("gpt_errors_total", "GPT desk errors", registry=REGISTRY)
 gpt_last_success_ts = Gauge(
     "gpt_last_success_ts", "GPT desk last success timestamp", registry=REGISTRY
@@ -88,6 +91,7 @@ def _update_loop() -> None:
         gross_pos_g.set(sum(gross(sym) for sym in md._symbols))
         cash_g.set(cash())
         equity_g.set(equity())
+        maker_ratio_g.set(maker_fill_ratio())
         warmup_complete_g.set(1 if getattr(md, "warmup_complete", False) else 0)
         if time.time() - last_hb >= 60:
             heartbeat_g.set(1)

--- a/atlasbot/secrets_loader.py
+++ b/atlasbot/secrets_loader.py
@@ -1,10 +1,10 @@
 # secrets_loader.py
-import boto3
 import base64
 import json
 import os
+
+import boto3
 from dotenv import load_dotenv
-from botocore.exceptions import ClientError
 
 load_dotenv()
 
@@ -25,6 +25,7 @@ def load_secret(secret_name: str, region_name: str = "us-east-1") -> dict:
     except Exception:
         return {}
 
+
 def get_coinbase_credentials():
     secret = load_secret("atlasbot/coinbase")
     if not secret:
@@ -37,6 +38,7 @@ def get_coinbase_credentials():
         "api_name": secret["COINBASE_API_NAME"],
         "private_key": formatted_key,
     }
+
 
 def get_openai_api_key():
     env_key = os.getenv("OPENAI_API_KEY")

--- a/atlasbot/signals/momentum.py
+++ b/atlasbot/signals/momentum.py
@@ -4,9 +4,11 @@ from atlasbot.market_data import get_market
 
 WINDOW = 15  # bars
 
+
 def _typical_price(bar: tuple[float, float, float, float]) -> float:
-    o, h, l, c = bar
-    return (o + h + l + c) / 4
+    o, h, low, c = bar
+    return (o + h + low + c) / 4
+
 
 def momentum(symbol: str) -> float:
     """Return normalised slope of approximate VWAP over last 15 bars."""

--- a/atlasbot/utils.py
+++ b/atlasbot/utils.py
@@ -9,7 +9,6 @@ Thin convenience layer around the `MarketData` singleton
 
 from __future__ import annotations
 
-import time
 from typing import List
 
 from atlasbot.config import SYMBOLS
@@ -17,6 +16,7 @@ from atlasbot.market_data import get_market
 
 # single global market-data object
 _md = get_market(SYMBOLS)
+
 
 # --------------------------------------------------------------------------- helpers
 def _ensure_ready(timeout: int = 30) -> None:
@@ -50,8 +50,8 @@ def calculate_atr(symbol: str, period: int = 10) -> float:
     if len(bars) < period + 1:
         return float("nan")
     trs = [
-        max(h, prev_close) - min(l, prev_close)
-        for prev_close, (_, h, l, _) in zip((b[3] for b in bars[:-1]), bars[1:])
+        max(h, prev_close) - min(low, prev_close)
+        for prev_close, (_, h, low, _) in zip((b[3] for b in bars[:-1]), bars[1:])
     ]
     return sum(trs) / period
 

--- a/cli/run_bot.py
+++ b/cli/run_bot.py
@@ -1,17 +1,19 @@
 import argparse
-import time
-import signal
-import os
-import logging
-import json
 import atexit
+import json
+import logging
+import os
+import signal
+import time
+
 import openai
 
+from atlasbot import risk
+from atlasbot.config import start_fee_updater
+from atlasbot.metrics import start_metrics_server
+from atlasbot.risk import SUMMARY_PATH
 from atlasbot.secrets_loader import get_openai_api_key
 from atlasbot.trader import IntradayTrader
-from atlasbot.metrics import start_metrics_server
-from atlasbot import risk
-from atlasbot.risk import SUMMARY_PATH
 
 openai.api_key = get_openai_api_key()
 
@@ -23,6 +25,7 @@ parser.add_argument("--backend", default="sim", choices=["sim", "paper"])
 parser.add_argument("-t", "--time", type=int, default=0, help="run time seconds")
 args = parser.parse_args()
 
+start_fee_updater()
 start_metrics_server()
 bot = IntradayTrader(backend=args.backend)
 stop_event = False

--- a/tests/test_ledger_snapshot.py
+++ b/tests/test_ledger_snapshot.py
@@ -1,0 +1,30 @@
+import importlib
+import os
+from datetime import datetime, timezone
+
+import atlasbot.execution.base as base_mod
+import atlasbot.risk as risk_mod
+
+
+class FakeDatetime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+
+def test_ledger_snapshot(monkeypatch, tmp_path):
+    risk = importlib.reload(risk_mod)
+    base = importlib.reload(base_mod)
+    monkeypatch.setattr(base, "PNL_PATH", tmp_path / "pnl.csv")
+    monkeypatch.setattr(risk, "fetch_price", lambda s: 100.0)
+    monkeypatch.setattr(risk, "datetime", FakeDatetime)
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        base.log_fill("BTC-USD", "buy", 100, 100, 0.0)
+        risk._risk._snapshot_ledger()
+    finally:
+        os.chdir(cwd)
+    ledger = tmp_path / f"data/ledger_{FakeDatetime.now():%Y-%m-%d}.jsonl"
+    assert ledger.exists()
+    assert len(ledger.read_text().splitlines()) == 1

--- a/tests/test_maker_ratio.py
+++ b/tests/test_maker_ratio.py
@@ -1,0 +1,41 @@
+import importlib
+
+import pytest
+
+import atlasbot.metrics as metrics_mod
+import atlasbot.risk as risk_mod
+
+
+class DummyMarket:
+    def __init__(self):
+        self._symbols = ["BTC-USD"]
+        self.reconnects = 0
+
+    def feed_latency(self):
+        return 0
+
+    def minute_bars(self, _):
+        return [1]
+
+
+def test_maker_ratio(monkeypatch):
+    metrics = importlib.reload(metrics_mod)
+    risk = importlib.reload(risk_mod)
+    monkeypatch.setattr(metrics, "get_market", lambda: DummyMarket())
+    monkeypatch.setattr(metrics, "feed_watchdog_check", lambda: None)
+    monkeypatch.setattr(risk, "fetch_price", lambda s: 100.0)
+    risk.record_fill("BTC-USD", "buy", 100, 100, 0.0, 0.0, maker=True)
+    risk.record_fill("BTC-USD", "sell", 100, 100, 0.0, 0.0, maker=False)
+
+    called = False
+
+    def fake_sleep(_):
+        nonlocal called
+        called = True
+        raise RuntimeError
+
+    monkeypatch.setattr(metrics.time, "sleep", fake_sleep)
+    with pytest.raises(RuntimeError):
+        metrics._update_loop()
+    assert called
+    assert metrics.maker_ratio_g._value.get() == pytest.approx(0.5)

--- a/tests/test_pnl_file.py
+++ b/tests/test_pnl_file.py
@@ -1,12 +1,19 @@
 import os
+
 import pandas as pd
+
+import atlasbot.execution.base as base
 import atlasbot.execution.sim as sim
-from atlasbot.execution.base import PNL_PATH
+
+PNL_PATH = base.PNL_PATH
 
 
 def test_pnl_row(monkeypatch, tmp_path):
     monkeypatch.setattr(sim, "fetch_price", lambda s: 100.0)
     monkeypatch.setattr(sim.random, "gauss", lambda m, s: 0.0)
+    monkeypatch.setattr(base, "PNL_PATH", tmp_path / "pnl.csv")
+    global PNL_PATH
+    PNL_PATH = base.PNL_PATH
     if os.path.exists(PNL_PATH):
         os.remove(PNL_PATH)
     sim.submit_order("buy", 100, "BTC-USD")
@@ -16,4 +23,3 @@ def test_pnl_row(monkeypatch, tmp_path):
     assert len(row) == 9
     assert row["fee"] >= 0
     assert row["slip"] >= 0
-

--- a/tests/test_pnl_snapshot.py
+++ b/tests/test_pnl_snapshot.py
@@ -1,8 +1,7 @@
 import os
-import json
-import importlib
-import atlasbot.risk as risk
+
 import atlasbot.execution.base as base
+import atlasbot.risk as risk
 
 
 def test_pnl_snapshot(monkeypatch, tmp_path):

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,15 +1,20 @@
 import importlib
-import atlasbot.signals.orderflow as of
-mom = importlib.import_module("atlasbot.signals.momentum")
 from collections import deque
+
+import atlasbot.signals.orderflow as of
+
+mom = importlib.import_module("atlasbot.signals.momentum")
+
 
 class FakeMarket:
     def minute_bars(self, _):
-        return deque([(1,2,0,1)]*20)
+        return deque([(1, 2, 0, 1)] * 20)
+
 
 def test_imbalance_range(monkeypatch):
     monkeypatch.setattr(of, "_orderflow", of.OrderFlow([]))
     assert -1.0 <= of.imbalance("BTC-USD") <= 1.0
+
 
 def test_momentum(monkeypatch):
     monkeypatch.setattr(mom, "get_market", lambda: FakeMarket())


### PR DESCRIPTION
## Summary
- enable fee updater thread and maker order logic
- snapshot ledger to daily jsonl file
- expose maker fill ratio metric
- honour MAX_HOLD_MIN constant
- document install steps
- add tests for new metrics and ledger snapshots

## Testing
- `ruff check .`
- `pytest -q`