### PR TITLE
Scale decision edge based on signal strength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 - Ledger snapshots written every minute
 - Maker fill ratio metric exposed
 - Configurable max hold time via MAX_HOLD_MIN
+- Decision engine scales edge by signal strength

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ python -m cli.run_bot --backend paper
 ```
 
 Fees are refreshed hourly by a background updater started at launch.
+Strong signals have their profit target scaled so the expected edge exceeds
+fees and slippage.
 
 Metrics are exposed at http://localhost:9000/metrics. GPT desk summaries are
 written to `logs/ai_advisor.log` every 10 minutes when `OPENAI_API_KEY` is set.

--- a/tests/test_strong_signals_trade.py
+++ b/tests/test_strong_signals_trade.py
@@ -1,0 +1,53 @@
+import pytest
+
+import atlasbot.config as cfg
+import atlasbot.trader as tr
+from atlasbot.decision_engine import DecisionEngine
+
+
+class DummyExec:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def submit_order(self, side: str, size_usd: float, symbol: str) -> None:
+        self.calls.append((side, size_usd, symbol))
+
+
+class DummyMarket:
+    def minute_bars(self, symbol: str) -> list[tuple[int, int, int, int]]:
+        return [(1, 1, 1, 1)] * 60
+
+
+def _setup_bot(
+    monkeypatch: "pytest.MonkeyPatch",
+) -> tuple[tr.IntradayTrader, DummyExec]:
+    monkeypatch.setattr(tr, "SYMBOLS", ["BTC-USD"])
+    monkeypatch.setattr(cfg, "SYMBOLS", ["BTC-USD"])
+    monkeypatch.setattr(tr, "fetch_price", lambda s: 100.0)
+    monkeypatch.setattr(tr, "calculate_atr", lambda s: 1.0)
+    monkeypatch.setattr(tr.risk, "check_risk", lambda order: True)
+    dummy = DummyExec()
+    monkeypatch.setattr(tr, "get_backend", lambda name=None: dummy)
+    dummy_market = DummyMarket()
+    monkeypatch.setattr(tr, "get_market", lambda: dummy_market)
+    import atlasbot.market_data as md
+
+    monkeypatch.setattr(md, "get_market", lambda symbols=None: dummy_market)
+    monkeypatch.setattr(md, "_market", dummy_market)
+    eng = DecisionEngine()
+    import atlasbot.decision_engine as de
+
+    monkeypatch.setattr(de, "imbalance", lambda s: 1.0)
+    monkeypatch.setattr(de, "momentum", lambda s: 1.0)
+    monkeypatch.setattr(de, "macro_bias", lambda s: 1.0)
+    bot = tr.IntradayTrader(decision_engine=eng, backend="sim")
+    return bot, dummy
+
+
+def test_trade_executes_on_strong_signal(monkeypatch):
+    bot, dummy = _setup_bot(monkeypatch)
+    bot.run_cycle()
+    assert dummy.calls
+    side, size_usd, symbol = dummy.calls[0]
+    assert side == "buy"
+    assert symbol == "BTC-USD"


### PR DESCRIPTION
## Summary
- scale `DecisionEngine.next_advice` edge output
- test that trades fire when signal strength is high
- document edge scaling in README and CHANGELOG

## Testing
- `pytest -q`

## Summary by Sourcery

Scale the trading edge output based on signal strength to ensure strong signals cover fees, add a test for strong-signal trades, and update documentation accordingly

New Features:
- Scale profit target edge by signal strength in DecisionEngine

Documentation:
- Document edge scaling in README and record change in CHANGELOG

Tests:
- Add test to verify trades execute on high signal strength