### PR TITLE
feat(core): tunable filters, breakout alpha, adaptive trade-count curb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 - Profit-first exits with ATR TP/SL
+- Tunable edge threshold and conflict filter
+- Breakout signal with adaptive trade-count curb
 - Maker vs taker tracking and conflict debounce
 - Circuit breaker and feed watchdog safeguards
 - Thread-safe ledger with stress test

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Metrics are exposed at http://localhost:9000/metrics. GPT desk summaries are
 written to `logs/ai_advisor.log` every 10 minutes when `OPENAI_API_KEY` is set.
 
 Metrics include `atlasbot_feed_watchdog_total` alongside PnL and latency gauges.
+New gauges track edge quality and trade cadence.
 
 ## Environment vars
 
@@ -52,6 +53,9 @@ Metrics include `atlasbot_feed_watchdog_total` alongside PnL and latency gauges.
 * OPENAI_MODEL        – override model for macro signal (default gpt-4o-mini)
 * EXECUTION_MODE      – sim | paper (default sim)
 * MIN_EDGE_BPS        – minimum edge threshold
+* CONFLICT_THRESH     – orderflow/momentum disagreement cutoff
+* MACRO_TTL_MIN       – minutes to cache GPT macro bias
+* BREAKOUT_WEIGHT     – ensemble weight for breakout signal
 * K_TP                – ATR-based take profit multiplier
 * K_SL                – ATR-based stop loss multiplier
 * MAX_HOLD_MIN        – maximum hold time in minutes

--- a/atlasbot/config.py
+++ b/atlasbot/config.py
@@ -20,7 +20,7 @@ SLIPPAGE_BPS = 4  # simulated slippage (basis points)
 # fee and minimum edge thresholds
 FEE_BPS = int(0.0025 * 10_000)
 FEE_FLAT = 0.10
-MIN_EDGE_BPS = 3
+MIN_EDGE_BPS = max(8, min(int(os.getenv("MIN_EDGE_BPS", "15")), 20))
 CURRENT_TAKER_BPS = FEE_BPS
 CURRENT_MAKER_BPS = FEE_BPS
 
@@ -39,6 +39,7 @@ LOG_PATH = "data/logs/sim_tradesOverNight.csv"
 W_ORDERFLOW = 0.5
 W_MOMENTUM = 0.3
 W_MACRO = 0.2
+BREAKOUT_WEIGHT = float(os.getenv("BREAKOUT_WEIGHT", "0.2"))
 
 # --- risk limits ------------------------------------------------------------
 MAX_GROSS_USD = 1_000
@@ -63,6 +64,9 @@ FEE_MIN_USD = FEE_FLAT
 
 # configurable max hold time for live and simulated trades (minutes)
 MAX_HOLD_MIN = int(os.getenv("MAX_HOLD_MIN", "30"))
+CONFLICT_THRESH = max(0.05, float(os.getenv("CONFLICT_THRESH", "0.20")))
+ALLOW_CONFLICT = os.getenv("ALLOW_CONFLICT", "false").lower() == "true"
+MACRO_TTL_MIN = max(15, int(os.getenv("MACRO_TTL_MIN", "60")))
 
 # execution costs
 TAKER_FEE = 0.0025  # Coinbase taker fee

--- a/atlasbot/decision_engine.py
+++ b/atlasbot/decision_engine.py
@@ -6,8 +6,14 @@ from pathlib import Path
 import numpy as np
 
 from atlasbot import risk
-from atlasbot.config import W_MACRO, W_MOMENTUM, W_ORDERFLOW, profit_target
-from atlasbot.signals import imbalance, macro_bias, momentum
+from atlasbot.config import (
+    BREAKOUT_WEIGHT,
+    W_MACRO,
+    W_MOMENTUM,
+    W_ORDERFLOW,
+    profit_target,
+)
+from atlasbot.signals import breakout, imbalance, macro_bias, momentum
 
 ADAPT_TEMP = float(os.getenv("ADAPT_TEMP", "2.0"))
 WEIGHTS_FILE = Path("data/weights.json")
@@ -21,6 +27,7 @@ class DecisionEngine:
             "orderflow": W_ORDERFLOW,
             "momentum": W_MOMENTUM,
             "macro": W_MACRO,
+            "breakout": BREAKOUT_WEIGHT,
         }
         self._last_adapt = 0.0
 
@@ -32,10 +39,12 @@ class DecisionEngine:
         im = imbalance(symbol)
         mo = momentum(symbol)
         ma = macro_bias(symbol)
+        br = breakout(symbol)
         score = (
             self.weights["orderflow"] * im
             + self.weights["momentum"] * mo
             + self.weights["macro"] * ma
+            + self.weights["breakout"] * br
         )
         bias = "long" if score > 0 else "short" if score < 0 else "flat"
         # scale edge so strong signals clear execution costs
@@ -48,6 +57,7 @@ class DecisionEngine:
                 "orderflow": im,
                 "momentum": mo,
                 "macro": ma,
+                "breakout": br,
             },
         }
 
@@ -60,7 +70,7 @@ class DecisionEngine:
         if len(set(returns)) <= 1:
             return
         edges = {}
-        for key in ("orderflow", "momentum", "macro"):
+        for key in ("orderflow", "momentum", "macro", "breakout"):
             sigs = [t.get("signals", {}).get(key, 0.0) for t in trades]
             if len(set(sigs)) <= 1:
                 corr = 0.0

--- a/atlasbot/signals/__init__.py
+++ b/atlasbot/signals/__init__.py
@@ -1,5 +1,6 @@
-from .orderflow import imbalance, poll_latency
-from .momentum import momentum
+from .breakout import breakout
 from .llm_macro import macro_bias
+from .momentum import momentum
+from .orderflow import imbalance, poll_latency
 
-__all__ = ["imbalance", "momentum", "macro_bias", "poll_latency"]
+__all__ = ["imbalance", "momentum", "macro_bias", "poll_latency", "breakout"]

--- a/atlasbot/signals/breakout.py
+++ b/atlasbot/signals/breakout.py
@@ -1,0 +1,22 @@
+from typing import Deque
+
+from atlasbot.market_data import get_market
+
+WINDOW = 20
+
+
+def breakout(symbol: str) -> float:
+    """Return 1 for long breakout, -1 for short breakout, else 0."""
+    bars: Deque[tuple[float, float, float, float]] = get_market().minute_bars(symbol)
+    if len(bars) <= WINDOW:
+        return 0.0
+    recent = list(bars)[-WINDOW - 1 :]
+    prev = [b[3] for b in recent[:-1]]
+    last = recent[-1][3]
+    if not prev:
+        return 0.0
+    if last > max(prev):
+        return 1.0
+    if last < min(prev):
+        return -1.0
+    return 0.0

--- a/atlasbot/signals/llm_macro.py
+++ b/atlasbot/signals/llm_macro.py
@@ -1,7 +1,10 @@
 import json
 import logging
 from datetime import datetime, timedelta, timezone
+
 from openai import OpenAI
+
+import atlasbot.config as cfg
 from atlasbot.config import OPENAI_MODEL
 from atlasbot.secrets_loader import get_openai_api_key
 
@@ -13,11 +16,12 @@ PROMPT = (
     "'headline': '...' } max 25 words."
 )
 
+
 class MacroBias:
-    def __init__(self, ttl_minutes: int = 60, enabled: bool = True):
+    def __init__(self, ttl_minutes: int = cfg.MACRO_TTL_MIN, enabled: bool = True):
         self.ttl = timedelta(minutes=ttl_minutes)
         self.enabled = enabled
-        self._cache = (0.0, 'llm_offline', datetime.now(timezone.utc) - self.ttl)
+        self._cache = (0.0, "llm_offline", datetime.now(timezone.utc) - self.ttl)
         self._last_warn = datetime.now(timezone.utc) - timedelta(hours=1)
 
     def _warn(self, reason: str) -> None:
@@ -45,7 +49,7 @@ class MacroBias:
             score = conf if bias == "long" else -conf if bias == "short" else 0.0
             headline = data.get("headline", "")
             return score, headline
-        except Exception as exc:                     # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             self._warn(str(exc))
             return 0.0, "llm_offline"
 
@@ -59,7 +63,9 @@ class MacroBias:
             self._cache = (score, headline, now)
         return score
 
+
 _macro = MacroBias()
+
 
 def macro_bias(symbol: str) -> float:
     return _macro.macro_bias(symbol)

--- a/tests/test_breakout.py
+++ b/tests/test_breakout.py
@@ -1,0 +1,22 @@
+import importlib
+from collections import deque
+
+bo = importlib.import_module("atlasbot.signals.breakout")
+
+
+class FakeMarket:
+    def __init__(self, bars):
+        self._bars = {"BTC-USD": deque(bars, maxlen=25)}
+
+    def minute_bars(self, sym):
+        return self._bars[sym]
+
+
+def test_breakout_signal(monkeypatch):
+    bars = [(i, i, i, i) for i in range(1, 22)]
+    monkeypatch.setattr(bo, "get_market", lambda symbols=None: FakeMarket(bars))
+    assert bo.breakout("BTC-USD") == 1
+
+    down = [(i, i, i, i) for i in range(22, 0, -1)]
+    monkeypatch.setattr(bo, "get_market", lambda symbols=None: FakeMarket(down))
+    assert bo.breakout("BTC-USD") == -1

--- a/tests/test_new_filters.py
+++ b/tests/test_new_filters.py
@@ -1,0 +1,73 @@
+import atlasbot.config as cfg
+import atlasbot.trader as tr
+
+
+class DummyExec:
+    def __init__(self):
+        self.calls = []
+
+    def submit_order(self, side: str, size_usd: float, symbol: str):
+        self.calls.append((side, size_usd, symbol))
+
+
+class DummyEngine:
+    def __init__(self, advice):
+        self._advice = advice
+
+    def next_advice(self, _symbol: str):
+        return self._advice
+
+
+def _setup(monkeypatch, advice):
+    monkeypatch.setattr(tr, "SYMBOLS", ["BTC-USD"])
+    monkeypatch.setattr(cfg, "SYMBOLS", ["BTC-USD"])
+    monkeypatch.setattr(tr, "fetch_price", lambda s: 100.0)
+    monkeypatch.setattr(tr, "calculate_atr", lambda s: 1.0)
+    monkeypatch.setattr(tr.risk, "check_risk", lambda order: True)
+    dummy = DummyExec()
+    monkeypatch.setattr(tr, "get_backend", lambda name=None: dummy)
+    bot = tr.IntradayTrader(decision_engine=DummyEngine(advice), backend="sim")
+    return bot, dummy
+
+
+def test_edge_threshold_env(monkeypatch):
+    monkeypatch.setattr(cfg, "MIN_EDGE_BPS", 80, raising=False)
+    advice = {
+        "bias": "long",
+        "edge": 0.002,
+        "confidence": 1.0,
+        "rationale": {"orderflow": 0.5, "momentum": 0.5, "macro": 0.0},
+    }
+    bot, dummy = _setup(monkeypatch, advice)
+    bot.run_cycle()
+    assert not dummy.calls
+
+
+def test_conflict_thresh_env(monkeypatch):
+    monkeypatch.setattr(cfg, "CONFLICT_THRESH", 0.6, raising=False)
+    advice = {
+        "bias": "long",
+        "edge": 0.05,
+        "confidence": 1.0,
+        "rationale": {"orderflow": -0.5, "momentum": 0.5, "macro": 0.0},
+    }
+    bot, dummy = _setup(monkeypatch, advice)
+    bot.run_cycle()
+    assert dummy.calls
+
+
+def test_dynamic_size_curb(monkeypatch):
+    advice = {
+        "bias": "long",
+        "edge": 0.05,
+        "confidence": 1.0,
+        "rationale": {"orderflow": 0.2, "momentum": 0.3, "macro": 0.0},
+    }
+    bot, dummy = _setup(monkeypatch, advice)
+    monkeypatch.setattr(tr.risk, "equity", lambda: 1000.0)
+    monkeypatch.setattr(tr.risk, "trade_count_day", lambda: 101)
+    bot.run_cycle()
+    assert dummy.calls
+    _, size_usd, _ = dummy.calls[0]
+    base = 1000.0 * cfg.RISK_PER_TRADE * 1.0 / (1.0 / 100.0)
+    assert size_usd == base * 0.75


### PR DESCRIPTION
## Summary
- add breakout signal module and wire into DecisionEngine
- expose env vars for edge threshold, conflict filter and macro TTL
- track daily trade count and macro bias accuracy in risk/metrics
- implement dynamic trade sizing based on trade count
- unit tests for env thresholds, breakout alpha and trade count throttle
- update README and changelog

## Testing
- `ruff check atlasbot/metrics.py atlasbot/decision_engine.py atlasbot/risk.py atlasbot/trader.py atlasbot/signals/breakout.py atlasbot/signals/llm_macro.py atlasbot/signals/__init__.py atlasbot/config.py tests/test_breakout.py tests/test_new_filters.py`
- `pytest -q`

## Summary by Sourcery

Introduce configurable filters and a breakout signal, enhance metric tracking, and implement adaptive trade sizing based on daily trade counts.

New Features:
- Introduce breakout signal module and integrate it into the decision engine with a tunable weight.
- Expose environment variables for minimum edge threshold, conflict filter settings, breakout weight, and macro TTL.
- Implement dynamic trade sizing that reduces position size after exceeding a daily trade count threshold.

Enhancements:
- Track daily trade count and macro bias hit rate in risk metrics and expose them as Prometheus gauges.
- Make LLM macro bias cache TTL configurable via environment variable.

Documentation:
- Update README and changelog with new metrics and tunable environment variables.

Tests:
- Add unit tests for environment threshold filters, breakout signal behavior, and dynamic trade-size throttle.