### PR TITLE
Implement Sprint-5 tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 - Profit-first exits with ATR TP/SL
+- ATR TP/SL exits with timeout in IntradayTrader
+- Prometheus exit counters
+- Paper backend retry with Fill dataclass
+- Heartbeat watchdog and ledger gzip
 - Tunable edge threshold and conflict filter
 - Breakout signal with adaptive trade-count curb
 - Maker vs taker tracking and conflict debounce
@@ -15,3 +19,6 @@
 - Decision engine scales edge by signal strength
 - Per-run CSV ledger
 - EXECUTION_MODE env to toggle maker vs taker
+
+## 0.4.0 - 2025-05-30
+- Sprint 5 features and bug fixes

--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ fees and slippage.
 
 Metrics are exposed at http://localhost:9000/metrics. GPT desk summaries are
 written to `logs/ai_advisor.log` every 10 minutes when `OPENAI_API_KEY` is set.
-
 Metrics include `atlasbot_feed_watchdog_total` alongside PnL and latency gauges.
-New gauges track edge quality and trade cadence.
+New gauges track edge quality, trade cadence and exit types.
 
 ## Environment vars
 

--- a/atlasbot/config.py
+++ b/atlasbot/config.py
@@ -67,6 +67,8 @@ SUMMARY_INTERVAL_MIN = int(os.getenv("SUMMARY_INTERVAL_MIN", "10"))
 
 # configurable max hold time for live and simulated trades (minutes)
 MAX_HOLD_MIN = int(os.getenv("MAX_HOLD_MIN", "30"))
+K_TP = float(os.getenv("K_TP", "2"))
+K_SL = float(os.getenv("K_SL", "2"))
 CONFLICT_THRESH = max(0.05, float(os.getenv("CONFLICT_THRESH", "0.20")))
 ALLOW_CONFLICT = os.getenv("ALLOW_CONFLICT", "false").lower() == "true"
 MACRO_TTL_MIN = max(15, int(os.getenv("MACRO_TTL_MIN", "60")))

--- a/atlasbot/execution/base.py
+++ b/atlasbot/execution/base.py
@@ -1,5 +1,6 @@
 import json
 import os
+from dataclasses import dataclass
 from datetime import datetime, timezone
 
 import pandas as pd
@@ -11,6 +12,15 @@ PNL_PATH = "data/logs/pnl.csv"
 
 
 FILL_DIR = "data/fills"
+
+
+@dataclass
+class Fill:
+    """Order fill information."""
+
+    order_id: str
+    qty: float
+    price: float
 
 
 def log_fill(
@@ -53,8 +63,6 @@ def log_fill(
         f.write(json.dumps(row) + "\n")
 
 
-def submit_maker_order(
-    side: str, size_usd: float, symbol: str
-) -> tuple[str, float, float] | None:
-    """Submit a maker (post-only) order. Return fill tuple or None."""
+def submit_maker_order(side: str, size_usd: float, symbol: str) -> Fill | None:
+    """Submit a maker (post-only) order. Return fill details or None."""
     raise NotImplementedError

--- a/atlasbot/execution/paper.py
+++ b/atlasbot/execution/paper.py
@@ -1,14 +1,15 @@
 import os
 import time
+from typing import Any
 
 import requests
 
 from atlasbot.utils import fetch_price
 
-from .base import log_fill
+from .base import Fill, log_fill
 
 
-def submit_order(side: str, size_usd: float, symbol: str) -> str:
+def submit_order(side: str, size_usd: float, symbol: str) -> Fill:
     """Send order to Coinbase paper API or fall back to instant fill."""
     api_key = os.getenv("COINBASE_PAPER_KEY")
     endpoint = "https://api.coinbase.com/api/v3/brokerage/orders"  # paper
@@ -16,7 +17,7 @@ def submit_order(side: str, size_usd: float, symbol: str) -> str:
         price = fetch_price(symbol)
         qty = size_usd / price
         log_fill(symbol, side, size_usd, price, 0.0)
-        return "paper-sim", qty, price
+        return Fill("paper-sim", qty, price)
 
     payload = {
         "side": side,
@@ -26,23 +27,28 @@ def submit_order(side: str, size_usd: float, symbol: str) -> str:
         "type": "market",
     }
     headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
-    try:
-        r = requests.post(endpoint, json=payload, headers=headers, timeout=5)
-        r.raise_for_status()
-        data = r.json()
-        order_id = data.get("order_id", "paper-unknown")
-        price = float(data.get("average_filled_price", fetch_price(symbol)))
-        qty = float(data.get("filled_size", 0))
-        log_fill(symbol, side, qty * price, price, 0.0)
-        return order_id, qty, price
-    except Exception:
-        price = fetch_price(symbol)
-        qty = size_usd / price
-        log_fill(symbol, side, size_usd, price, 0.0)
-        return "paper-error", qty, price
+    for attempt in range(3):
+        try:
+            r = requests.post(endpoint, json=payload, headers=headers, timeout=5)
+            if r.status_code == 429 or 400 <= r.status_code < 500:
+                time.sleep(2**attempt)
+                continue
+            r.raise_for_status()
+            data: dict[str, Any] = r.json()
+            order_id = data.get("order_id", "paper-unknown")
+            price = float(data.get("average_filled_price", fetch_price(symbol)))
+            qty = float(data.get("filled_size", 0))
+            log_fill(symbol, side, qty * price, price, 0.0)
+            return Fill(order_id, qty, price)
+        except Exception:
+            time.sleep(2**attempt)
+    price = fetch_price(symbol)
+    qty = size_usd / price
+    log_fill(symbol, side, size_usd, price, 0.0)
+    return Fill("paper-error", qty, price)
 
 
-def submit_maker_order(side: str, size_usd: float, symbol: str):
+def submit_maker_order(side: str, size_usd: float, symbol: str) -> Fill | None:
     """Maker order via paper API, return None if not filled."""
     api_key = os.getenv("COINBASE_PAPER_KEY")
     if not api_key:
@@ -69,7 +75,7 @@ def submit_maker_order(side: str, size_usd: float, symbol: str):
         qty = float(data.get("filled_size", 0))
         if qty:
             log_fill(symbol, side, qty * price, price, 0.0, maker=True)
-            return order_id, qty, price
+            return Fill(order_id, qty, price)
     except Exception:
         pass
     return None

--- a/atlasbot/execution/sim.py
+++ b/atlasbot/execution/sim.py
@@ -4,10 +4,10 @@ import time
 from atlasbot.config import SLIPPAGE_BPS
 from atlasbot.utils import fetch_price
 
-from .base import log_fill
+from .base import Fill, log_fill
 
 
-def submit_order(side: str, size_usd: float, symbol: str) -> str:
+def submit_order(side: str, size_usd: float, symbol: str) -> Fill:
     """Simulated immediate fill at current market price."""
     price = fetch_price(symbol)
     slip_pct = random.gauss(0, SLIPPAGE_BPS / 10_000)
@@ -15,15 +15,15 @@ def submit_order(side: str, size_usd: float, symbol: str) -> str:
     qty = size_usd / fill_price
     exec_id = f"sim-{time.time()}"
     log_fill(symbol, side, size_usd, fill_price, size_usd * slip_pct)
-    return exec_id, qty, fill_price
+    return Fill(exec_id, qty, fill_price)
 
 
-def submit_maker_order(side: str, size_usd: float, symbol: str):
+def submit_maker_order(side: str, size_usd: float, symbol: str) -> Fill | None:
     """Attempt maker order; 50% chance to fill."""
     if random.random() < 0.5:
         price = fetch_price(symbol)
         qty = size_usd / price
         exec_id = f"maker-{time.time()}"
         log_fill(symbol, side, size_usd, price, 0.0, maker=True)
-        return exec_id, qty, price
+        return Fill(exec_id, qty, price)
     return None

--- a/atlasbot/run_logger.py
+++ b/atlasbot/run_logger.py
@@ -6,9 +6,9 @@ import os
 from datetime import datetime, timezone
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
-
 import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
 
 RUN_DIR = REPO_ROOT / "data" / "runs"
 RUN_DIR.mkdir(parents=True, exist_ok=True)

--- a/data/ledger_2025-05-30.jsonl
+++ b/data/ledger_2025-05-30.jsonl
@@ -1,0 +1,3 @@
+{"timestamp": "2025-05-30T02:46:53.845130+00:00", "symbol": "BTC-USD", "side": "buy", "notional": 100, "price": 100, "fee": 0.0, "slip": 0.0, "realised": 0.0, "mtm": 0.0, "maker": true}
+{"timestamp": "2025-05-30T02:46:53.845153+00:00", "symbol": "BTC-USD", "side": "sell", "notional": 100, "price": 100, "fee": 0.0, "slip": 0.0, "realised": 0.0, "mtm": 0, "maker": false}
+{"timestamp": "2025-05-30T02:46:54.103040+00:00", "symbol": "BTC-USD", "side": "buy", "notional": 100, "price": 100, "fee": 0.1, "slip": 0.2, "realised": 0.0, "mtm": 0.0, "maker": false}

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="atlasbot",
-    version="0.3.0",
+    version="0.4.0",
     packages=find_packages(),  # finds the inner atlasbot package
     python_requires=">=3.10",
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+import os
+
+import pytest
+
+os.environ.setdefault("ATLAS_TEST", "1")
+
+
+class DummyMarket:
+    def minute_bars(self, _sym):
+        return [(1, 1, 1, 1)] * 60
+
+    def latest_trade(self, _sym):
+        return 100.0
+
+    def wait_ready(self, _timeout=0):
+        return True
+
+
+@pytest.fixture(autouse=True)
+def patch_market(monkeypatch):
+    if os.getenv("USE_REAL_MD"):
+        yield
+        return
+    import atlasbot.signals as sig
+
+    dummy = DummyMarket()
+    monkeypatch.setattr("atlasbot.market_data.get_market", lambda symbols=None: dummy)
+    monkeypatch.setattr("atlasbot.utils._get_md", lambda: dummy, raising=False)
+    sig.momentum.__globals__["get_market"] = lambda symbols=None: dummy
+    sig.breakout.__globals__["get_market"] = lambda symbols=None: dummy
+    yield

--- a/tests/test_ai_desk.py
+++ b/tests/test_ai_desk.py
@@ -1,13 +1,14 @@
-import asyncio
+import importlib
 import logging
 from types import SimpleNamespace
-import importlib
 
 from atlasbot import ai_desk
 
 
 def test_ai_summary_bad_json(monkeypatch, caplog):
-    bad = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="{"))])
+    bad = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="{"))]
+    )
     monkeypatch.setattr(ai_desk.client.chat.completions, "create", lambda *a, **k: bad)
     ai_desk.client.api_key = "x"
     caplog.set_level(logging.WARNING)
@@ -17,10 +18,18 @@ def test_ai_summary_bad_json(monkeypatch, caplog):
 
 
 def test_ai_summary_good(monkeypatch, tmp_path):
-    good = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content='{"bias":"long","confidence":1,"headline":"ok"}'))])
+    good = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content='{"bias":"long","confidence":1,"headline":"ok"}'
+                )
+            )
+        ]
+    )
     monkeypatch.setattr(ai_desk.client.chat.completions, "create", lambda *a, **k: good)
     ai_desk.client.api_key = "x"
-    monkeypatch.setenv("AI_ADVISOR_LOG", str(tmp_path/"ai.log"))
+    monkeypatch.setenv("AI_ADVISOR_LOG", str(tmp_path / "ai.log"))
     importlib.reload(ai_desk)
     monkeypatch.setattr(ai_desk.client.chat.completions, "create", lambda *a, **k: good)
     ai_desk.client.api_key = "x"

--- a/tests/test_env_exec_mode.py
+++ b/tests/test_env_exec_mode.py
@@ -3,6 +3,7 @@ import importlib
 import atlasbot.config as cfg_mod
 import atlasbot.trader as tr_mod
 from atlasbot.decision_engine import DecisionEngine
+from atlasbot.execution.base import Fill
 
 
 class DummyExec:
@@ -12,11 +13,11 @@ class DummyExec:
 
     def submit_maker_order(self, side: str, size_usd: float, symbol: str):
         self.maker += 1
-        return "id", 1.0, 100.0
+        return Fill("id", 1.0, 100.0)
 
     def submit_order(self, side: str, size_usd: float, symbol: str):
         self.taker += 1
-        return "id", 1.0, 100.0
+        return Fill("id", 1.0, 100.0)
 
 
 class DummyMarket:
@@ -35,6 +36,7 @@ def _run_bot(monkeypatch, mode: str) -> DummyExec:
     monkeypatch.setattr(tr.risk, "check_risk", lambda order: True)
     dummy = DummyExec()
     monkeypatch.setattr(tr, "get_backend", lambda name=None: dummy)
+    monkeypatch.setattr(tr.IntradayTrader, "_exit_position", lambda *a, **k: None)
     dummy_market = DummyMarket()
     monkeypatch.setattr(tr, "get_market", lambda: dummy_market)
     import atlasbot.market_data as md

--- a/tests/test_exit_close.py
+++ b/tests/test_exit_close.py
@@ -1,0 +1,27 @@
+import importlib
+
+import atlasbot.trader as tr_mod
+from atlasbot.execution.base import Fill
+
+
+class DummyExec:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def submit_order(self, side: str, size_usd: float, symbol: str):
+        self.calls.append((side, size_usd, symbol))
+        return Fill("id", size_usd / 100.0, 100.0)
+
+
+def test_exit_close_tp(monkeypatch):
+    tr = importlib.reload(tr_mod)
+    bot = tr.IntradayTrader(backend="sim")
+    bot.exec = DummyExec()
+    prices = [100.0, 103.0]
+    monkeypatch.setattr(tr, "fetch_price", lambda s: prices.pop(0))
+    monkeypatch.setattr(tr.time, "sleep", lambda s: None)
+    before = tr.metrics.exit_tp_total._value.get()
+    bot._exit_position("BTC-USD", "buy", 1.0, 100.0, 1.0)
+    after = tr.metrics.exit_tp_total._value.get()
+    assert after == before + 1
+    assert bot.exec.calls

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -1,8 +1,9 @@
-import threading
-import pytest
+import os
 
 import atlasbot.market_data as md
 from atlasbot.config import SYMBOLS
+
+os.environ["USE_REAL_MD"] = "1"
 
 
 class FakeWS:
@@ -30,6 +31,7 @@ def test_rest_fallback(monkeypatch):
     monkeypatch.setattr(md, "SEED_TIMEOUT", 0.0)
     monkeypatch.setattr(md.websocket, "WebSocketApp", lambda *a, **k: FakeWS())
     import requests
+
     monkeypatch.setattr(requests, "get", fake_get)
 
     md._market = None
@@ -39,4 +41,3 @@ def test_rest_fallback(monkeypatch):
     assert market.mode == "rest"
     for sym in SYMBOLS:
         assert market.latest_trade(sym) == 100.0
-

--- a/tests/test_paper_retry.py
+++ b/tests/test_paper_retry.py
@@ -1,0 +1,50 @@
+import importlib
+
+import requests
+
+import atlasbot.execution.paper as paper_mod
+
+
+class FakeResp:
+    def __init__(self, status: int, data=None):
+        self.status_code = status
+        self._data = data or {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError()
+
+    def json(self):
+        return self._data
+
+
+def test_paper_order_ok(monkeypatch):
+    paper = importlib.reload(paper_mod)
+    monkeypatch.setenv("COINBASE_PAPER_KEY", "x")
+    monkeypatch.setattr(paper, "fetch_price", lambda s: 100.0)
+    monkeypatch.setattr(
+        paper.requests,
+        "post",
+        lambda *a, **k: FakeResp(
+            200, {"order_id": "ok", "average_filled_price": "100", "filled_size": "1"}
+        ),
+    )
+    fill = paper.submit_order("buy", 100, "BTC-USD")
+    assert fill.order_id == "ok"
+
+
+def test_paper_order_fail(monkeypatch):
+    paper = importlib.reload(paper_mod)
+    monkeypatch.setenv("COINBASE_PAPER_KEY", "x")
+    monkeypatch.setattr(paper, "fetch_price", lambda s: 100.0)
+    calls = []
+
+    def bad_post(*a, **k):
+        calls.append(1)
+        return FakeResp(500)
+
+    monkeypatch.setattr(paper.requests, "post", bad_post)
+    monkeypatch.setattr(paper.time, "sleep", lambda s: None)
+    fill = paper.submit_order("buy", 100, "BTC-USD")
+    assert fill.order_id == "paper-error"
+    assert len(calls) >= 3

--- a/tests/test_strong_signals_trade.py
+++ b/tests/test_strong_signals_trade.py
@@ -3,14 +3,16 @@ import pytest
 import atlasbot.config as cfg
 import atlasbot.trader as tr
 from atlasbot.decision_engine import DecisionEngine
+from atlasbot.execution.base import Fill
 
 
 class DummyExec:
     def __init__(self) -> None:
         self.calls = []
 
-    def submit_order(self, side: str, size_usd: float, symbol: str) -> None:
+    def submit_order(self, side: str, size_usd: float, symbol: str):
         self.calls.append((side, size_usd, symbol))
+        return Fill("id", size_usd / 100.0, 100.0)
 
 
 class DummyMarket:

--- a/tests/test_warm_start.py
+++ b/tests/test_warm_start.py
@@ -1,27 +1,37 @@
+import os
+
 import atlasbot.market_data as md
 from atlasbot.config import SYMBOLS
+
+os.environ["USE_REAL_MD"] = "1"
+
 
 class FakeWS:
     def run_forever(self, *a, **k):
         raise md.websocket._exceptions.WebSocketBadStatusException("err", 403)
+
     def close(self):
         pass
+
 
 def fake_get(url, timeout=5):
     class Resp:
         ok = True
+
         def json(self):
             if "candles" in url:
-                return [[0,1,2,3,4,0]] * 150
+                return [[0, 1, 2, 3, 4, 0]] * 150
             return {"price": "100"}
+
     return Resp()
+
 
 def test_warm_start(monkeypatch):
     monkeypatch.setattr(md.websocket, "WebSocketApp", lambda *a, **k: FakeWS())
     monkeypatch.setattr(md, "SEED_TIMEOUT", 0)
     import requests
+
     monkeypatch.setattr(requests, "get", fake_get)
     md._market = None
     market = md.get_market(SYMBOLS)
     assert market.wait_ready(2)
-


### PR DESCRIPTION
## Summary
- add tests for exit logic and paper backend
- implement ATR TP/SL exits with timeout and Prometheus counters
- add Fill dataclass and paper retry logic
- gzip old ledgers and add heartbeat watchdog
- document release in CHANGELOG and bump version
- ensure tests patch market data for offline runs

## Testing
- `ruff check atlasbot/utils.py atlasbot/signals/orderflow.py tests/conftest.py tests/test_market_data.py tests/test_warm_start.py tests/test_trade_count_curb.py tests/test_new_filters.py tests/test_filters.py`
- `black -q atlasbot/utils.py atlasbot/signals/orderflow.py tests/conftest.py tests/test_market_data.py tests/test_warm_start.py tests/test_trade_count_curb.py tests/test_new_filters.py tests/test_filters.py`
- `isort --profile black atlasbot/utils.py atlasbot/signals/orderflow.py tests/conftest.py tests/test_market_data.py tests/test_warm_start.py tests/test_trade_count_curb.py tests/test_new_filters.py tests/test_filters.py`
- `pytest tests/test_decision_engine.py::test_weighted_output tests/test_env_exec_mode.py::test_env_exec_mode tests/test_new_filters.py::test_dynamic_size_curb -q`