### PR TITLE
Sprint7.2 adaptive risk metrics

### DIFF
--- a/atlasbot/config.py
+++ b/atlasbot/config.py
@@ -1,11 +1,11 @@
 # --- traded symbols ---------------------------------------------------------
 import os
 
-SYMBOLS = os.getenv(
-    "SYMBOLS",
+SYMBOLS_DEFAULT = (
     "BTC-USD,ETH-USD,SOL-USD,ADA-USD,LTC-USD,"
-    "XRP-USD,DOGE-USD,LINK-USD,DOT-USD,HBAR-USD,ALGO-USD",
+    "XRP-USD,DOGE-USD,LINK-USD,DOT-USD,HBAR-USD,ALGO-USD"
 ).split(",")
+SYMBOLS = os.getenv("SYMBOLS", ",".join(SYMBOLS_DEFAULT)).split(",")
 
 # --- strategy parameters ----------------------------------------------------
 SLIPPAGE_BPS = 4  # simulated slippage (basis points)

--- a/atlasbot/metrics.py
+++ b/atlasbot/metrics.py
@@ -17,6 +17,7 @@ from atlasbot.risk import cash, daily_pnl, equity, gross, maker_fill_ratio, tota
 from atlasbot.signals import poll_latency
 
 REGISTRY = CollectorRegistry()
+feed_latency_ms = Histogram("feed_latency_ms", "WS gap", ["symbol"], registry=REGISTRY)
 ws_latency_g = Gauge(
     "atlasbot_ws_latency_ms",
     "WebSocket price latency (ms)",
@@ -43,6 +44,7 @@ gross_pos_g = Gauge(
 )
 cash_g = Gauge("atlasbot_cash_usd", "Available cash", registry=REGISTRY)
 equity_g = Gauge("atlasbot_equity_usd", "Total account equity", registry=REGISTRY)
+cum_pnl_usd = Gauge("cum_pnl_usd", "Cumulative realized PnL in USD", registry=REGISTRY)
 heartbeat_g = Gauge("bot_alive", "Bot heartbeat", registry=REGISTRY)
 maker_ratio_g = Gauge(
     "atlasbot_maker_fill_ratio", "Maker to total fill ratio", registry=REGISTRY

--- a/atlasbot/metrics.py
+++ b/atlasbot/metrics.py
@@ -17,7 +17,13 @@ from atlasbot.risk import cash, daily_pnl, equity, gross, maker_fill_ratio, tota
 from atlasbot.signals import poll_latency
 
 REGISTRY = CollectorRegistry()
-feed_latency_ms = Histogram("feed_latency_ms", "WS gap", ["symbol"], registry=REGISTRY)
+feed_latency_ms = Histogram(
+    "feed_latency_ms",
+    "WS gap",
+    ["symbol"],
+    registry=REGISTRY,
+    buckets=(1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000)
+)
 ws_latency_g = Gauge(
     "atlasbot_ws_latency_ms",
     "WebSocket price latency (ms)",

--- a/atlasbot/trader.py
+++ b/atlasbot/trader.py
@@ -17,7 +17,7 @@ from atlasbot.config import profit_target
 from atlasbot.decision_engine import DecisionEngine
 from atlasbot.execution import get_backend
 from atlasbot.gpt_report import GPTTrendAnalyzer
-from atlasbot.market_data import get_market
+from atlasbot.market_data import get_market, get_spread_bps
 from atlasbot.secrets_loader import get_openai_api_key
 from atlasbot.utils import calculate_atr, fetch_price, fetch_volatility
 
@@ -219,7 +219,8 @@ class IntradayTrader:
             edge_bps = abs(advice.get("edge", 0.0) * 10_000)
             metrics.edge_g.set(edge_bps)
             metrics.edge_hist.observe(edge_bps)
-            if edge_bps <= cfg.FEE_BPS + cfg.SLIPPAGE_BPS + cfg.MIN_EDGE_BPS:
+            min_edge = max(cfg.MIN_EDGE_BPS, get_spread_bps(symbol))
+            if edge_bps <= cfg.FEE_BPS + cfg.SLIPPAGE_BPS + min_edge:
                 continue
             side = "buy" if advice["bias"] == "long" else "sell"
             price = fetch_price(symbol)

--- a/tests/test_spread_clamp.py
+++ b/tests/test_spread_clamp.py
@@ -1,0 +1,8 @@
+from atlasbot.market_data import _SPREAD, get_spread_bps
+
+
+def test_spread_clamp():
+    _SPREAD["XYZ"] = 0.2
+    assert get_spread_bps("XYZ") == 1
+    _SPREAD["XYZ"] = 30
+    assert get_spread_bps("XYZ") == 15


### PR DESCRIPTION
## Summary
- track per-symbol spread and clamp edge threshold
- monitor websocket feed latency with histogram
- add cumulative PnL gauge
- run latency breaker in background thread
- test spread clamping

## Testing
- `ruff check . --select F,E,I,W --fix`
- `black .`
- `isort atlasbot/market_data.py atlasbot/risk.py atlasbot/metrics.py tests/test_spread_clamp.py atlasbot/trader.py cli/run_bot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a890beea0832794505539ab969852

## Summary by Sourcery

Add adaptive risk metrics by tracking per-symbol spreads and WebSocket feed latency, dynamically clamping trade edge thresholds, and exposing cumulative PnL metrics while running a latency-based circuit breaker in the background.

New Features:
- Fetch and track per-symbol bid-ask spreads in bps via a background thread with clamping between 1 and 15.
- Monitor WebSocket feed latency per symbol using a Prometheus histogram metric.
- Expose cumulative realized PnL as a Prometheus gauge.
- Run a background latency breaker task to trip the circuit on high feed latency.

Enhancements:
- Apply dynamic spread-based edge threshold in trading logic instead of a static minimum edge.
- Introduce a separate SYMBOLS_DEFAULT list and derive SYMBOLS from environment overrides.
- Refactor tick callback to propagate message details for latency measurement.

Tests:
- Add a test to validate spread clamping behavior.