### PR TITLE
Add hybrid signal and maker-first execution

### DIFF
--- a/atlasbot/decision_engine.py
+++ b/atlasbot/decision_engine.py
@@ -1,25 +1,67 @@
 import json
-import logging
 import os
 import time
+from collections import defaultdict, deque
+from datetime import datetime, timezone
 from math import exp
 from pathlib import Path
 
 from numpy import corrcoef as _corr
 
 from atlasbot import risk
-from atlasbot.config import (
-    BREAKOUT_WEIGHT,
-    FEE_BPS,
-    W_MACRO,
-    W_MOMENTUM,
-    W_ORDERFLOW,
-    profit_target,
-)
+from atlasbot.config import (BREAKOUT_WEIGHT, FEE_BPS, MIN_EDGE_BPS,
+                             SLIPPAGE_BPS, W_MACRO, W_MOMENTUM, W_ORDERFLOW)
+from atlasbot.market_data import get_spread_bps
+from atlasbot.run_logger import log_decision
 from atlasbot.signals import breakout, imbalance, macro_bias, momentum
+from atlasbot.utils import fetch_price
 
 ADAPT_TEMP = float(os.getenv("ADAPT_TEMP", "2.0"))
 WEIGHTS_FILE = Path("data/weights.json")
+
+# price history for hybrid signal
+_tick_history: dict[str, deque[float]] = defaultdict(lambda: deque(maxlen=10))
+_window_history: dict[str, deque[tuple[float, float]]] = defaultdict(lambda: deque())
+
+
+def _zscore(seq: list[float]) -> float:
+    if len(seq) < 2:
+        return 0.0
+    mean = sum(seq) / len(seq)
+    var = sum((x - mean) ** 2 for x in seq) / len(seq)
+    std = var**0.5
+    return 0.0 if std == 0 else (seq[-1] - mean) / std
+
+
+def hybrid_signal(symbol: str) -> float:
+    """Return 30 s momentum z-score plus 10-tick mean reversion."""
+    price = fetch_price(symbol)
+    _tick_history[symbol].append(price)
+    now = time.time()
+    window = _window_history[symbol]
+    window.append((now, price))
+    while window and now - window[0][0] > 30:
+        window.popleft()
+    momentum = _zscore([p for _, p in window])
+    ticks = _tick_history[symbol]
+    mean_rev = 0.0
+    if ticks:
+        avg = sum(ticks) / len(ticks)
+        if avg:
+            mean_rev = -(price - avg) / avg
+    score = momentum + mean_rev
+    return max(-1.0, min(1.0, score))
+
+
+def expected_edge_bps(
+    signal: float,
+    tick_size: float,
+    mid_px: float,
+    fee_bps: int,
+    slippage_bps: int,
+) -> float:
+    """Return expected edge in basis points."""
+    return 1e4 * (signal * tick_size / mid_px) - fee_bps - slippage_bps
 
 
 class DecisionEngine:
@@ -37,6 +79,7 @@ class DecisionEngine:
     # --------------------------------------------------------------- public API
     def next_advice(self, symbol: str) -> dict:
         """Return trading advice for *symbol* with scaled edge."""
+        start = time.perf_counter_ns()
         if time.time() - self._last_adapt >= 3600:
             self._adapt_weights()
         im = imbalance(symbol)
@@ -49,20 +92,29 @@ class DecisionEngine:
             + self.weights["macro"] * ma
             + self.weights["breakout"] * br
         )
+        price = fetch_price(symbol)
         bias = "long" if score > 0 else "short" if score < 0 else "flat"
-        # scale edge so strong signals clear execution costs
-        raw_edge = profit_target(symbol) * score * 2
-        edge_bps = abs(raw_edge) * 10_000
-        logging.debug(
-            "edge=%.2f  strength=%.2f  fees=%.2f",
-            edge_bps,
-            abs(score),
-            FEE_BPS,
+        edge_bps = expected_edge_bps(score, 0.01, price, FEE_BPS, SLIPPAGE_BPS)
+        latency_ms = (time.perf_counter_ns() - start) / 1e6
+        log_decision(
+            {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "symbol": symbol,
+                "px": price,
+                "side": bias,
+                "edge_bps": edge_bps,
+                "score": score,
+                "latency_ms": latency_ms,
+                "spread_bps": get_spread_bps(symbol),
+                "order_id": "",
+            }
         )
+        if edge_bps < MIN_EDGE_BPS:
+            bias = "flat"
         return {
             "bias": bias,
             "confidence": abs(score),
-            "edge": raw_edge,
+            "edge": edge_bps / 10_000,
             "rationale": {
                 "orderflow": im,
                 "momentum": mo,

--- a/atlasbot/execution_engine.py
+++ b/atlasbot/execution_engine.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import time
+
+from atlasbot.config import CURRENT_TAKER_BPS
+from atlasbot.execution.base import Fill
+
+
+def fill_probability(edge_bps: float, spread_bps: float) -> float:
+    """Return expected fill probability for a maker order."""
+    if spread_bps <= 0:
+        return 0.0
+    return min(1.0, 0.6 * (edge_bps / spread_bps) ** 1.3)
+
+
+def place_maker(
+    exec_api: object,
+    side: str,
+    size_usd: float,
+    symbol: str,
+    edge_bps: float,
+    spread_bps: float,
+) -> Fill | None:
+    """Place maker-first order with timed fallback to taker."""
+    filled = None
+    if hasattr(exec_api, "submit_maker_order"):
+        filled = exec_api.submit_maker_order(side, size_usd, symbol)
+        if filled:
+            return filled
+        wait_s = max(2.0, 1.0 / max(fill_probability(edge_bps, spread_bps), 1e-6))
+        time.sleep(wait_s)
+    if edge_bps > CURRENT_TAKER_BPS:
+        return exec_api.submit_order(side, size_usd, symbol)
+    return None

--- a/atlasbot/run_logger.py
+++ b/atlasbot/run_logger.py
@@ -13,6 +13,9 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 RUN_DIR = REPO_ROOT / "data" / "runs"
 RUN_DIR.mkdir(parents=True, exist_ok=True)
 RUN_CSV = RUN_DIR / f"ledger_{datetime.now(timezone.utc):%Y-%m-%d_%H-%M-%S}.csv"
+DECISIONS_CSV = (
+    REPO_ROOT / "logs" / f"decisions_{datetime.now(timezone.utc):%Y-%m-%d}.csv"
+)
 
 
 def append(row: dict) -> None:
@@ -21,4 +24,13 @@ def append(row: dict) -> None:
     RUN_CSV.parent.mkdir(parents=True, exist_ok=True)
     df = pd.DataFrame([row])
     df.to_csv(RUN_CSV, mode="a", header=header, index=False)
+    os.sync()
+
+
+def log_decision(row: dict) -> None:
+    """Append decision *row* to the daily CSV ledger."""
+    header = not DECISIONS_CSV.exists()
+    DECISIONS_CSV.parent.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame([row])
+    df.to_csv(DECISIONS_CSV, mode="a", header=header, index=False)
     os.sync()

--- a/docs/ENGINE_V2_CHANGELOG.md
+++ b/docs/ENGINE_V2_CHANGELOG.md
@@ -1,0 +1,2 @@
+## Unreleased
+- Engine v2 hybrid signal and maker-first execution improvements.

--- a/tests/test_decision.py
+++ b/tests/test_decision.py
@@ -1,0 +1,8 @@
+import pytest
+
+from atlasbot.decision_engine import expected_edge_bps
+
+
+def test_expected_edge():
+    edge = expected_edge_bps(0.5, 0.01, 1.0, fee_bps=10, slippage_bps=5)
+    assert edge == pytest.approx(1e4 * (0.5 * 0.01 / 1.0) - 15)

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,0 +1,8 @@
+import pytest
+
+from atlasbot.execution_engine import fill_probability
+
+
+def test_fill_probability():
+    prob = fill_probability(20, 2)
+    assert prob == pytest.approx(min(1.0, 0.6 * (20 / 2) ** 1.3))


### PR DESCRIPTION
## Summary
- implement hybrid signal and edge calculation
- maker-first routing helpers with fill-probability model
- log decisions to daily CSV
- document ENGINE_V2 changelog
- add unit tests for expected edge and fill probability

## Testing
- `pytest tests/test_decision.py tests/test_execution.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683b1e839c488327baa94ed06e80c1b5

## Summary by Sourcery

Introduce a hybrid trading signal and basis-point edge model, enhance execution routing with a maker-first fallback strategy, and log detailed decision metrics to a daily CSV ledger.

New Features:
- Add a hybrid signal combining momentum z‐score and mean reversion
- Add expected_edge_bps to compute expected edge in basis points
- Add maker-first execution helpers: fill_probability and place_maker

Enhancements:
- Log each decision with timestamp, price, edge, spread, score and latency to a daily CSV
- Use expected_edge_bps and a minimum edge threshold to adjust DecisionEngine biases
- Incorporate slippage, fees, and spread into edge calculation in DecisionEngine

Documentation:
- Document ENGINE_V2 changes in a new changelog file

Tests:
- Add unit tests for expected_edge_bps and fill_probability