### PR TITLE
Moderate aggression patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ New gauges track edge quality, trade cadence and exit types.
 * LOG_LEVEL           – DEBUG|INFO|WARN|ERROR (default INFO)
 * OPENAI_MODEL        – override model for macro signal (default gpt-4o-mini)
 * EXECUTION_MODE      – maker | taker (default maker)
-* MIN_EDGE_BPS        – minimum edge threshold
+* MIN_EDGE_BPS        – minimum edge threshold (default 5)
+* FALLBACK_DELAY      – seconds to wait before taker fallback (default 1.5)
 * CYCLE_SEC          – main loop delay seconds (default 1)
 * SYMBOLS            – comma list of trading pairs
 * MAX_NOTIONAL       – position size USD cap (default 200)

--- a/atlasbot/config.py
+++ b/atlasbot/config.py
@@ -10,16 +10,19 @@ SYMBOLS = os.getenv("SYMBOLS", ",".join(SYMBOLS_DEFAULT)).split(",")
 # --- strategy parameters ----------------------------------------------------
 SLIPPAGE_BPS = 4  # simulated slippage (basis points)
 # fee and minimum edge thresholds
-FEE_BPS = int(0.0025 * 10_000)
+FEE_BPS_MAKER = 0
+FEE_BPS_TAKER = 25
 FEE_FLAT = 0.10
-MIN_EDGE_BPS = int(os.getenv("MIN_EDGE_BPS", "6"))
-CURRENT_TAKER_BPS = FEE_BPS
-CURRENT_MAKER_BPS = FEE_BPS
+MIN_EDGE_BPS = int(os.getenv("MIN_EDGE_BPS", "5"))
+FALLBACK_DELAY = float(os.getenv("FALLBACK_DELAY", "1.5"))
+TARGET_VOL_BPS = 35
+CURRENT_TAKER_BPS = FEE_BPS_TAKER
+CURRENT_MAKER_BPS = FEE_BPS_MAKER
 
 
 def profit_target(sym: str) -> float:
     """Return cost-aware profit target for *sym* as a percentage."""
-    fee_bps = FEE_BPS
+    fee_bps = FEE_BPS_TAKER
     slip = SLIPPAGE_BPS
     return (fee_bps + slip + MIN_EDGE_BPS) / 10_000
 
@@ -98,7 +101,7 @@ def refresh_fee_tier() -> None:
             j = r.json()
             CURRENT_MAKER_BPS = int(float(j.get("maker_fee_rate", 0)) * 10_000)
             CURRENT_TAKER_BPS = int(float(j.get("taker_fee_rate", 0)) * 10_000)
-            MIN_EDGE_BPS = 2 if CURRENT_TAKER_BPS < FEE_BPS else 3
+            MIN_EDGE_BPS = 2 if CURRENT_TAKER_BPS < FEE_BPS_TAKER else 3
             _last_fee_check = time.time()
     except Exception:  # noqa: BLE001
         pass

--- a/atlasbot/execution_engine.py
+++ b/atlasbot/execution_engine.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 
-from atlasbot.config import CURRENT_TAKER_BPS
+from atlasbot.config import CURRENT_TAKER_BPS, FALLBACK_DELAY
 from atlasbot.execution.base import Fill
 
 
@@ -27,7 +27,9 @@ def place_maker(
         filled = exec_api.submit_maker_order(side, size_usd, symbol)
         if filled:
             return filled
-        wait_s = max(2.0, 1.0 / max(fill_probability(edge_bps, spread_bps), 1e-6))
+        wait_s = max(
+            FALLBACK_DELAY, 1.0 / max(fill_probability(edge_bps, spread_bps), 1e-6)
+        )
         time.sleep(wait_s)
     if edge_bps > CURRENT_TAKER_BPS:
         return exec_api.submit_order(side, size_usd, symbol)

--- a/atlasbot/trader.py
+++ b/atlasbot/trader.py
@@ -220,7 +220,7 @@ class IntradayTrader:
             metrics.edge_g.set(edge_bps)
             metrics.edge_hist.observe(edge_bps)
             min_edge = max(cfg.MIN_EDGE_BPS, get_spread_bps(symbol))
-            if edge_bps <= cfg.FEE_BPS + cfg.SLIPPAGE_BPS + min_edge:
+            if edge_bps <= cfg.FEE_BPS_TAKER + cfg.SLIPPAGE_BPS + min_edge:
                 continue
             side = "buy" if advice["bias"] == "long" else "sell"
             price = fetch_price(symbol)

--- a/docs/ENGINE_V2_CHANGELOG.md
+++ b/docs/ENGINE_V2_CHANGELOG.md
@@ -1,3 +1,6 @@
 ## Unreleased
 - Engine v2 hybrid signal and maker-first execution improvements.
 - Fix CI timeout by bypassing market-data readiness and capping reconnect delay.
+- Moderate aggression patch: lower edge hurdle, vol-scaled sizing and maker
+  fallback delay.
+

--- a/tests/test_decision.py
+++ b/tests/test_decision.py
@@ -1,8 +1,10 @@
 import pytest
 
+from atlasbot import decision_engine
 from atlasbot.decision_engine import expected_edge_bps
 
 
-def test_expected_edge():
-    edge = expected_edge_bps(0.5, 0.01, 1.0, fee_bps=10, slippage_bps=5)
-    assert edge == pytest.approx(1e4 * (0.5 * 0.01 / 1.0) - 15)
+def test_expected_edge(monkeypatch):
+    monkeypatch.setattr(decision_engine, "vol_window_std", lambda: 0.01)
+    edge = expected_edge_bps(0.5, 1.0, spread_bps=5)
+    assert edge == pytest.approx(1e4 * 0.5 * 0.01 / 1.0 - (0 + 4 + 0.2 * 5))

--- a/tests/test_edge.py
+++ b/tests/test_edge.py
@@ -1,0 +1,8 @@
+from atlasbot import decision_engine
+from atlasbot.decision_engine import expected_edge_bps
+
+
+def test_edge_low_hurdle(monkeypatch):
+    monkeypatch.setattr(decision_engine, "vol_window_std", lambda: 0.001575)
+    edge = expected_edge_bps(0.8, mid=0.45, spread_bps=5)
+    assert edge >= 5

--- a/tests/test_env_exec_mode.py
+++ b/tests/test_env_exec_mode.py
@@ -28,7 +28,8 @@ def _run_bot(monkeypatch, mode: str) -> DummyExec:
     monkeypatch.setenv("EXECUTION_MODE", mode)
     cfg = importlib.reload(cfg_mod)
     tr = importlib.reload(tr_mod)
-    monkeypatch.setattr(cfg, "FEE_BPS", 0)
+    monkeypatch.setattr(cfg, "FEE_BPS_MAKER", 0)
+    monkeypatch.setattr(cfg, "FEE_BPS_TAKER", 0)
     monkeypatch.setattr(cfg, "SLIPPAGE_BPS", 0)
     monkeypatch.setattr(cfg, "MIN_EDGE_BPS", 0)
     import importlib as _importlib

--- a/tests/test_profit_target.py
+++ b/tests/test_profit_target.py
@@ -4,4 +4,4 @@ import atlasbot.config as cfg
 def test_profit_target_edge():
     for sym in cfg.SYMBOLS:
         pt = cfg.profit_target(sym)
-        assert pt > (cfg.FEE_BPS + cfg.SLIPPAGE_BPS) / 10_000
+        assert pt > (cfg.FEE_BPS_TAKER + cfg.SLIPPAGE_BPS) / 10_000

--- a/tests/test_strong_signals_trade.py
+++ b/tests/test_strong_signals_trade.py
@@ -24,7 +24,8 @@ def _setup_bot(
 ) -> tuple[tr.IntradayTrader, DummyExec]:
     monkeypatch.setattr(tr, "SYMBOLS", ["BTC-USD"])
     monkeypatch.setattr(cfg, "SYMBOLS", ["BTC-USD"])
-    monkeypatch.setattr(cfg, "FEE_BPS", 0)
+    monkeypatch.setattr(cfg, "FEE_BPS_MAKER", 0)
+    monkeypatch.setattr(cfg, "FEE_BPS_TAKER", 0)
     monkeypatch.setattr(cfg, "SLIPPAGE_BPS", 0)
     monkeypatch.setattr(cfg, "MIN_EDGE_BPS", 0)
     import importlib as _importlib


### PR DESCRIPTION
## Summary
- add edge hurdle test and update existing tests
- tune decision engine edge calculation
- update config for maker/taker fees and fallback delay
- adjust trader risk guard and order fallback
- document new env var and changelog entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bad37466483279dd940e7fa67e98c

## Summary by Sourcery

Moderate strategy aggression by scaling expected edge with recent volatility, reducing the minimum edge threshold, introducing a maker-to-taker fallback delay, and updating fee configurations, tests, and documentation.

New Features:
- Introduce volatility-scaled edge calculation in the decision engine
- Add configurable FALLBACK_DELAY for maker-to-taker order fallback

Enhancements:
- Separate maker and taker fee settings with updated defaults
- Lower default MIN_EDGE_BPS threshold from 6 to 5 basis points

Documentation:
- Document new FALLBACK_DELAY environment variable in README
- Add changelog entry for the moderate aggression patch

Tests:
- Add test for low edge hurdle with volatility scaling
- Update existing tests to reflect maker/taker fee config changes