### PR TITLE
Add diagnostics module for runtime env summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,4 @@
 
 ## 0.4.0 - 2025-05-30
 - Sprint 5 features and bug fixes
+- Diagnostics module summarising env + last rejects

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Metrics are exposed at http://localhost:9000/metrics. GPT desk summaries are
 written to `logs/ai_advisor.log` every 10 minutes when `OPENAI_API_KEY` is set.
 Metrics include `atlasbot_feed_watchdog_total` alongside PnL and latency gauges.
 New gauges track edge quality, trade cadence and exit types.
+Run `python -m atlasbot.diagnostics` to print environment and recent rejects.
 
 ## Environment vars
 

--- a/atlasbot/diagnostics.py
+++ b/atlasbot/diagnostics.py
@@ -1,0 +1,107 @@
+"""Runtime diagnostics helpers."""
+
+from __future__ import annotations
+
+import csv
+import io
+import os
+from collections import defaultdict, deque
+from datetime import datetime, timezone
+from typing import Deque, Dict, List
+
+import atlasbot.config as cfg
+import atlasbot.risk as risk
+from atlasbot.secrets_loader import get_coinbase_credentials, get_openai_api_key
+
+_REJECTS: Dict[str, Deque[dict]] = defaultdict(lambda: deque(maxlen=100))
+
+
+def record_reject(
+    filter_name: str, reason: str, edge_bps: float, **extra: object
+) -> None:
+    """Store a trade rejection event."""
+    _REJECTS[filter_name].appendleft(
+        {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "reason": reason,
+            "edge_bps": edge_bps,
+            **extra,
+        }
+    )
+
+
+def last_rejects(filter_name: str, n: int = 10) -> List[dict]:
+    """Return the most recent *n* rejections for *filter_name*."""
+    return list(_REJECTS.get(filter_name, []))[:n]
+
+
+def get_env_config() -> dict:
+    """Return environment and config information."""
+    env_keys = [
+        "PAPER_CASH",
+        "MAX_NOTIONAL",
+        "MAX_GROSS_USD",
+        "EXECUTION_MODE",
+        "COINBASE_PAPER_KEY",
+        "OPENAI_API_KEY",
+    ]
+    env = {k: os.getenv(k) for k in env_keys}
+    creds = get_coinbase_credentials()
+    env["COINBASE_API_NAME"] = creds.get("api_name")
+    env["OPENAI_API_KEY"] = get_openai_api_key() or env.get("OPENAI_API_KEY")
+    config = {
+        "MAX_NOTIONAL": cfg.MAX_NOTIONAL,
+        "MAX_GROSS_USD": cfg.MAX_GROSS_USD,
+        "EXECUTION_MODE": cfg.EXECUTION_MODE,
+        "FEE_BPS_MAKER": cfg.FEE_BPS_MAKER,
+        "FEE_BPS_TAKER": cfg.FEE_BPS_TAKER,
+        "SLIPPAGE_BPS": cfg.SLIPPAGE_BPS,
+        "MIN_EDGE_BPS": cfg.MIN_EDGE_BPS,
+        "CONFLICT_THRESH": cfg.CONFLICT_THRESH,
+        "SYMBOLS": ",".join(cfg.SYMBOLS),
+    }
+    missing = [k for k, v in env.items() if not v]
+    return {"env": env, "config": config, "missing": missing}
+
+
+def gating_status() -> dict:
+    """Return current gate states."""
+    return {
+        "circuit_breaker": risk.circuit_breaker_active(),
+        "kill_switch": risk.kill_switch_triggered(),
+    }
+
+
+def summary_csv(n: int = 10) -> str:
+    """Return CSV summary of config, gating and rejects."""
+    info = get_env_config()
+    gate = gating_status()
+
+    def _csv(rows: List[dict]) -> str:
+        if not rows:
+            return ""
+        buf = io.StringIO()
+        writer = csv.DictWriter(buf, fieldnames=rows[0].keys())
+        writer.writeheader()
+        for r in rows:
+            writer.writerow(r)
+        return buf.getvalue()
+
+    config_rows = [{"key": k, "value": v} for k, v in info["config"].items()]
+    gate_rows = [{"gate": k, "status": v} for k, v in gate.items()]
+    reject_rows = []
+    for name, dq in _REJECTS.items():
+        for rec in list(dq)[:n]:
+            reject_rows.append({"filter": name, **rec})
+    parts = ["# CONFIG", _csv(config_rows), "# GATES", _csv(gate_rows)]
+    if reject_rows:
+        parts.extend(["# REJECTS", _csv(reject_rows)])
+    return "\n".join(parts)
+
+
+def main() -> None:  # pragma: no cover - CLI helper
+    print(summary_csv())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,28 @@
+import importlib
+
+import atlasbot.diagnostics as diagnostics
+
+
+def test_record_and_fetch_rejects():
+    diag = importlib.reload(diagnostics)
+    diag.record_reject("edge", "below threshold", 4.0, symbol="BTC-USD")
+    diag.record_reject("edge", "below threshold", 3.0, symbol="ETH-USD")
+    rec = diag.last_rejects("edge", 1)[0]
+    assert rec["edge_bps"] == 3.0
+    assert rec["symbol"] == "ETH-USD"
+
+
+def test_env_config(monkeypatch):
+    diag = importlib.reload(diagnostics)
+    monkeypatch.setenv("PAPER_CASH", "9999")
+    info = diag.get_env_config()
+    assert info["env"]["PAPER_CASH"] == "9999"
+    assert "MAX_NOTIONAL" in info["config"]
+
+
+def test_summary_csv():
+    diag = importlib.reload(diagnostics)
+    diag.record_reject("risk", "limit", 10.0, symbol="BTC-USD")
+    out = diag.summary_csv(5)
+    assert "BTC-USD" in out
+    assert "CONFIG" in out


### PR DESCRIPTION
## Summary
- implement `diagnostics.py` with helpers for env summary and reject tracking
- expose CLI entry to print diagnostics
- unit test diagnostics helpers
- document usage in README
- note change in changelog

## Testing
- `isort atlasbot/diagnostics.py tests/test_diagnostics.py`
- `black atlasbot/diagnostics.py tests/test_diagnostics.py`
- `ruff check atlasbot/diagnostics.py tests/test_diagnostics.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bd4f63a308327989a3fe4d7e04232

## Summary by Sourcery

Introduce a diagnostics module to report runtime environment, configuration limits, gate status, and recent trade rejects via a CLI, with associated tests and documentation updates.

New Features:
- Add diagnostics module for environmental and reject summaries
- Expose a CLI entry point (`python -m atlasbot.diagnostics`) to print diagnostics

Documentation:
- Update README with diagnostics usage instructions
- Add changelog entry for the diagnostics module summarising env and rejects

Tests:
- Add unit tests for diagnostics helpers (record_reject, get_env_config, summary_csv)